### PR TITLE
Rebar3 template: remove start.sh in favour of having it in rebar.config

### DIFF
--- a/tools/templates/nova.template
+++ b/tools/templates/nova.template
@@ -10,7 +10,6 @@
 {dir, "{{name}}/src/views"}.
 
 {template, "nova/sys.config", "{{name}}/config/sys.config"}.
-{template, "nova/start.sh", "{{name}}/start.sh"}.
 {template, "nova/routes.erl", "{{name}}/priv/{{name}}.routes.erl"}.
 {template, "nova/app.src", "{{name}}/src/{{name}}.app.src"}.
 {template, "nova/app.erl", "{{name}}/src/{{name}}_app.erl"}.

--- a/tools/templates/nova/rebar.config
+++ b/tools/templates/nova/rebar.config
@@ -1,5 +1,8 @@
 {erl_opts, [debug_info]}.
 {src_dirs, ["src", "src/controllers"]}.
+
+{shell, [{config, "./config/sys.config"}]}.
+
 {erlydtl_opts, [{doc_root, "src/views"},
                 {recursive, true},
                 {libraries, [

--- a/tools/templates/nova/start.sh
+++ b/tools/templates/nova/start.sh
@@ -1,1 +1,0 @@
-ERL_FLAGS="-config config/sys.config" rebar3 shell

--- a/tools/templates/nova_rest.template
+++ b/tools/templates/nova_rest.template
@@ -9,7 +9,6 @@
 {dir, "{{name}}/src/controllers"}.
 
 {template, "nova/sys_rest.config", "{{name}}/config/sys.config"}.
-{template, "nova/start.sh", "{{name}}/start.sh"}.
 {template, "nova/routes.erl", "{{name}}/priv/{{name}}.routes.erl"}.
 {template, "nova/app_rest.src", "{{name}}/src/{{name}}.app.src"}.
 {template, "nova/app.erl", "{{name}}/src/{{name}}_app.erl"}.


### PR DESCRIPTION
Since rebar3 supports to pass options when invoking the `shell` task we can remove the start.sh-file and have the sys.config-option in our rebar.config.