### PR TITLE
Makes it possible to instrument cowboy with additional options

### DIFF
--- a/src/nova_request_plugin.erl
+++ b/src/nova_request_plugin.erl
@@ -60,6 +60,10 @@ plugin_info() ->
      ]}.
 
 
+%%%%%%%%%%%%%%%%%%%%%%
+%% Private functions
+%%%%%%%%%%%%%%%%%%%%%%
+
 modulate_state(State, []) -> {ok, State};
 modulate_state(State = #{req := Req, controller_data := ControllerData}, [parse_bindings|Tl]) ->
     Bindings = cowboy_req:bindings(Req),


### PR DESCRIPTION
This commit enables the user to add additional options to cowboy. Options can be set from sys.config with the following structure:

```
 {nova, [
         {cowboy_configuration, #{
                                  stream_handlers => [cowboy_metrics_h, nova_stream_h, cowboy_compress_h, cowboy_stream_h],
                                  middlewares => [cowboy_router, cowboy_handler],
                                  options => #{
                                               metrics_callback => fun nova_metric_prometheus_instrumenter:observe/1,
                                               ...
                                              }},
```

Note that by setting either `stream_handlers` or `middlewares` replaces the entire list which can totally change the behaviour of Nova. So use with caution! 