### PR TITLE
Give the user control over headers in security handlers

### DIFF
--- a/src/nova_security_plugin.erl
+++ b/src/nova_security_plugin.erl
@@ -28,6 +28,11 @@ pre_http_request(State = #{req := Req, secure := {Module, Function}}, _Options) 
         false ->
             {ok, State2} = nova_http_handler:render_page(401, State),
             {stop, State2};
+        {false, Headers} ->
+            {ok, #{req := Req} = State2} = nova_http_handler:render_page(401, State),
+            Headers0 = cowboy_req:resp_headers(Req),
+            Req0 = cowboy_req:set_resp_headers(maps:merge(Headers0, Headers), Req),
+            {ok, State2#{req => Req0}};
         {redirect, Route} ->
             Req0 = cowboy_req:set_resp_headers(#{<<"Location">> => list_to_binary(Route)}, Req),
             {stop, State#{resp_status := 302, req := Req0}}


### PR DESCRIPTION
One can now return ```{false, Headers :: #{binary() => iodata()}``` to return additional header values