### PR TITLE
Call security handler for ws endpoints

### DIFF
--- a/src/nova_plugin.erl
+++ b/src/nova_plugin.erl
@@ -65,11 +65,12 @@
 
 -include_lib("nova/include/nova.hrl").
 
--type request_type() :: pre_http_request | post_http_request | pre_ws_request | post_ws_request.
+-type request_type() :: pre_http_request | post_http_request | pre_ws_upgrade | pre_ws_request | post_ws_request.
 -export_type([request_type/0]).
 
 -define(REQUEST_TYPE(Type), Type == pre_http_request orelse
         Type == post_http_request orelse
+        Type == pre_ws_upgrade orelse
         Type == pre_ws_request orelse
         Type == post_ws_request).
 

--- a/src/nova_security_plugin.erl
+++ b/src/nova_security_plugin.erl
@@ -32,7 +32,7 @@ pre_http_request(State = #{req := Req, secure := {Module, Function}}, _Options) 
             {ok, #{req := Req0} = State2} = nova_http_handler:render_page(401, State),
             Headers0 = cowboy_req:resp_headers(Req0),
             Req1 = cowboy_req:set_resp_headers(maps:merge(Headers0, Headers), Req0),
-            {ok, State2#{req => Req1}};
+            {stop, State2#{req => Req1}};
         {redirect, Route} ->
             Req0 = cowboy_req:set_resp_headers(#{<<"Location">> => list_to_binary(Route)}, Req),
             {stop, State#{resp_status := 302, req := Req0}}

--- a/src/nova_ws_handler.erl
+++ b/src/nova_ws_handler.erl
@@ -30,33 +30,24 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Public functions      %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
-init(Req, State = #{mod := Mod, controller_data := ControllerData, secure := false}) ->
-    %% Call the http-handler in order to correctly handle potential plugins for the http-request
-    ControllerData0 = ControllerData#{req => Req},
-    case Mod:init(ControllerData0) of
-        {ok, NewControllerData} ->
-            {cowboy_websocket, Req, State#{controller_data => NewControllerData}};
-        Error ->
-            ?ERROR("Websocket handler ~p returned unkown result ~p", [Mod, Error]),
-            Req1 = cowboy_req:reply(500, Req),
-            {ok, Req1, State}
-    end;
 init(Req, State) ->
-    %% We have something that needs securing
-    case nova_security_plugin:pre_http_request(State, #{}) of
-        {ok, State0 = #{req := Req}} ->
-            %% Recurse with secure set to false. This is hacky, but we can live with that now
-            init(Req, State0#{secure => false});
-        {stop, State0 = #{req := Req}} ->
-            %% We have no way to exit other than marking this is a unauthrized attempt and close in
-            %% websocket_init/1 function
-            init(Req, State0#{should_terminate => true,
-                              secure => false})
+    %% Call the http-handler in order to correctly handle potential plugins for the http-request
+    {ok, PrePlugins} = nova_plugin:get_plugins(pre_ws_upgrade),
+    case run_plugins(PrePlugins, pre_ws_upgrade, State) of
+        {ok, State0 = #{controller_data := ControllerData, mod := Mod}} ->
+            ControllerData0 = ControllerData#{req => Req},
+            case Mod:init(ControllerData0) of
+                {ok, NewControllerData} ->
+                    {cowboy_websocket, Req, State0#{controller_data => NewControllerData}};
+                Error ->
+                    ?ERROR("Websocket handler ~p returned unkown result ~p", [Mod, Error]),
+                    Req1 = cowboy_req:reply(500, Req),
+                    {ok, Req1, State0}
+            end;
+        Stop ->
+            Stop
     end.
 
-
-websocket_init(#{should_terminate := true}) ->
-    {close, 1008, <<"Unauthorized">>};
 websocket_init(State = #{mod := Mod}) ->
     case erlang:function_exported(Mod, websocket_init, 1) of
         true ->
@@ -81,32 +72,14 @@ terminate(Reason, PartialReq, State = #{mod := Mod}) ->
 
 handle_ws(Mod, Func, Args, State = #{controller_data := _ControllerData}) ->
     {ok, PrePlugins} = nova_plugin:get_plugins(pre_ws_request),
-    case pre_process(State, PrePlugins) of
-        {break, State0} ->
+    case run_plugins(PrePlugins, pre_ws_request, State) of
+        {ok, State0} ->
             invoke_controller(Mod, Func, Args, State0);
-        {stop, State0} ->
-            {stop, State0};
-        {error, Reason} ->
-            ?ERROR("Websocket plugin (~p:~p) stopped with error ~p", [Mod, Func, Reason]),
-            {stop, State};
-        State0 ->
-            invoke_controller(Mod, Func, Args, State0)
+        Stop ->
+            Stop
     end;
 handle_ws(Mod, Func, Args, State) ->
     handle_ws(Mod, Func, Args, State#{controller_data => #{}}).
-
-pre_process(State, []) ->
-    State;
-pre_process(State, [{_, #{module := PluginMod, options := Options}}|T]) ->
-    case PluginMod:pre_ws_request(State, Options) of
-        {ok, State0} ->
-            pre_process(State0, T);
-        Error ->
-            Error
-    end;
-pre_process(State, [_|T]) ->
-    pre_process(State, T).
-
 
 invoke_controller(Mod, Func, Args, State = #{controller_data := ControllerData}) ->
     try
@@ -128,9 +101,11 @@ invoke_controller(Mod, Func, Args, State = #{controller_data := ControllerData})
         case ControllerResult of
             {stop, _} = Stop ->
                 Stop;
-            _ ->
+            {_, State0} ->
                 {ok, PostPlugins} = nova_plugin:get_plugins(post_ws_request),
-                run_post_plugin(ControllerResult, PostPlugins)
+                run_plugins(PostPlugins, post_ws_request, State0);
+            _ ->
+                ok
         end
     catch
         Type:Reasons:Stacktrace ->
@@ -138,63 +113,29 @@ invoke_controller(Mod, Func, Args, State = #{controller_data := ControllerData})
             {stop, State}
     end.
 
-run_post_plugin(ControllerResult, []) ->
-    ControllerResult;
-run_post_plugin(ControllerResult, PostPlugins) ->
-    Hibernate = element(size(ControllerResult), ControllerResult) == hibernate,
-    case post_process(ControllerResult, Hibernate, PostPlugins) of
-        %% Returning {ok, ...} is the same as {break, ...}
-        {OkOrBreake, Frames, State0, Options} when OkOrBreake == reply orelse
-                                                   OkOrBreake == break ->
-            %% There must be a nicer way to achive the following case but I can't figure it out now.
-            %% TODO! Rewrite into something better
-            case maps:get(hibernate, Options, false) of
-                true ->
-                    {reply, Frames, State0, hibernate};
-                _ ->
-                    {reply, Frames, State0}
-            end;
-        {OkOrBreake, State0, Options} when OkOrBreake == ok orelse
-                                           OkOrBreake == break ->
-            %% TODO! Rewrite this case aswell.
-            case maps:get(hibernate, Options, false) of
-                true ->
-                    {ok, State0, hibernate};
-                _ ->
-                    {ok, State0}
-            end;
+
+run_plugins([], _Callback, State) ->
+    {ok, State};
+run_plugins([{_Prio, #{id := Id, module := Module, options := Options}}|Tl], Callback, State) ->
+    try Module:Callback(State, Options) of
+        {ok, State0} ->
+            run_plugins(Tl, Callback, State0);
+        %% Stop indicates that we want the entire pipe of plugins/controller to be stopped.
         {stop, State0} ->
             {stop, State0};
+        %% Break is used to signal that we are stopping further executing of plugins within the same Callback
+        {break, State0} ->
+            {ok, State0};
         {error, Reason} ->
-            %% Just output the error message. Maybe include information about which plugin that
-            %% returned the error?
-            ?ERROR("Post-plugin exited with reason ~p. Closing connection.", [Reason]),
-            {stop, no_state}
+            ?ERROR("Plugin (~p:~p/2) with id: ~p returned error with reason ~p", [Module, Callback, Id, Reason]),
+            {stop, State}
+    catch
+        Type:Reason:Stacktrace ->
+            ?ERROR("Plugin with id: ~p failed in execution. Type: ~p Reason: ~p~nStacktrace:~n~p",
+                   [Id, Type, Reason, Stacktrace]),
+            {stop, State}
     end.
 
-post_process(ControllerResult, _, []) ->
-    ControllerResult;
-post_process(ControllerResult, Hibernate, [{_, #{module := PluginMod, options := Options}} | T]) ->
-    Options0 = case Hibernate of
-                   true ->
-                       Options#{hibernate => true};
-                   _ ->
-                       Options
-               end,
-    Result = case size(ControllerResult) of
-                 3 ->
-                     PluginMod:post_ws_request(ControllerResult, Options0);
-                 _ ->
-                     {ControlCode, State} = ControllerResult,
-                     PluginMod:post_ws_request({ControlCode, [], State}, Options0)
-             end,
-    case Result of
-        X when element(1, X) == ok orelse
-               element(1, X) == reply ->
-            post_process(X, Hibernate, T);
-        Error ->
-            Error
-    end.
 
 -ifdef(TEST).
 

--- a/tools/templates/nova/sys.config
+++ b/tools/templates/nova/sys.config
@@ -13,7 +13,8 @@
          %% Plugins is written on form {RequestType, Module, Options, Priority}
          %% Priority is that the lowest number is executed first
          {plugins, [
-                    {pre_http_request, nova_security_plugin, #{}, 0}
+                    {pre_http_request, nova_security_plugin, #{}, 0},
+                    {pre_ws_upgrade, nova_security_plugin, #{}, 0}
                    ]}
         ]}
   %% Please change your app.src-file instead if you intend to add app-specific configurations


### PR DESCRIPTION
Nova does not currently support plugins for websockets which makes it impossible to invoke the security-plugin in a dynamic way. So this commit hard-codes call for the security-handler when having a secure websocket path .