### PR TITLE
Support prefix and security on app-level

### DIFF
--- a/docs/06_building-releases.md
+++ b/docs/06_building-releases.md
@@ -19,3 +19,22 @@ If you would include the application `nova_admin` into your app `testapp`, your 
 ```
 
 This tells nova that you want to include the `nova_admin` application and prefix all of its paths with `/admin`.
+
+### App definition
+
+| Key         | Definition                                                   | Default value        |
+|-------------|--------------------------------------------------------------|----------------------|
+| name        | Name of the app                                              | *required*           |
+| routes_file | Path to route file                                           | priv/$APP.routes.erl |
+| prefix      | If the entire app should be prefixed                         | ""                   |
+| security    | Secure all routes for this application with security handler | false                |
+
+
+Example
+```erlang
+    #{name => "myapp",
+      routes_file => "priv/myapp.routes.erl",
+      prefix => "/my_app",
+      security => {my_sec_handler, sec_function}
+    }
+```


### PR DESCRIPTION
This adds support for setting prefix and security globally over an included nova app (Included via `nova_applications`-list in sys.config. 

Closes #72 