### PR TITLE
WIP: Json atom keys

### DIFF
--- a/src/nova_request_plugin.erl
+++ b/src/nova_request_plugin.erl
@@ -73,7 +73,7 @@ modulate_state(State = #{req := Req, controller_data := ControllerData}, [parse_
 modulate_state(State, [decode_json_body|Tl]) ->
     modulate_state(State, [{decode_json, []}|Tl]);
 modulate_state(State, [decode_json_body_atom_keys | Tl]) ->
-    modulate_state(State, [{decode_json, [atom_keys]}| Tl]);
+    modulate_state(State, [{decode_json, [existing_atom_keys]}| Tl]);
 modulate_state(State = #{req :=  Req = #{headers := #{<<"content-type">> := <<"application/json", _/binary>>}},
                          controller_data := ControllerData},
                [{decode_json, Opts}|Tl]) ->


### PR DESCRIPTION
Added a change to nova_request_plugin that allows to get json keys as atoms. Using json decode with existing_atom_keys. 

Two options now for decoding json with the plugin:
#{decode_json_body => true} or #{decode_json_body_atom_keys => true}