### PR TITLE
added so you could have routes in a module if you want

### DIFF
--- a/src/nova_router.erl
+++ b/src/nova_router.erl
@@ -460,8 +460,14 @@ parse_routefile(#{name := Application, routes_file := RoutesFile} = AppRoute) ->
         Filepath ->
             ?DEBUG("Processing routefile ~s", [Filepath]),
             AppPrefix = maps:get(prefix, AppRoute, ""),
-            RouteFilePath = filename:join([Filepath, RoutesFile]),
-            {ok, AppRoutes} = file:consult(RouteFilePath),
+            AppRoutes = case application:get_env(nova, routing, undefined) of
+                            undefined ->
+                                RouteFilePath = filename:join([Filepath, RoutesFile]),
+                                {ok, FileRoutes} = file:consult(RouteFilePath),
+                                FileRoutes;
+                            {ok, Module} ->
+                                Module:routes()
+                        end,
             lists:foreach(fun(AppMap) ->
                                   %% Extract the information from routes
                                   Prefix = filename:join([AppPrefix, maps:get(prefix, AppMap, "")]),


### PR DESCRIPTION
Idea here is that you could set a routing config in sys.config that takes a module name.

That module need to ahve a function called routes/0. That will return a list of maps. In this way we woudl be more beam friendly and not force to have a .erl file for routes.

Both options will work.