### PR TITLE
Fix problem with websocket plugin not being able to get the variable bindings

### DIFF
--- a/src/nova_ws_handler.erl
+++ b/src/nova_ws_handler.erl
@@ -43,7 +43,7 @@ init(Req = #{method := Method}, State = #{entries := Routes}) ->
 
             %% Call the http-handler in order to correctly handle potential plugins for the http-request
             {ok, PrePlugins} = nova_plugin:get_plugins(pre_ws_upgrade),
-            case run_plugins(PrePlugins, pre_ws_upgrade, NormalizedState0) of
+            case run_plugins(PrePlugins, pre_ws_upgrade, NormalizedState0#{req => Req}) of
                 {ok, State0 = #{controller_data := ControllerData, mod := Mod}} ->
                     ControllerData0 = ControllerData#{req => Req},
                     upgrade_ws(Mod, Req, State0, ControllerData0);


### PR DESCRIPTION
Fixed by adding the Request data to the State that is passed to pre_ws_upgrade plugin