### PR TITLE
Pass controller_data into security_plugin auth function

### DIFF
--- a/src/nova_security_plugin.erl
+++ b/src/nova_security_plugin.erl
@@ -21,11 +21,10 @@
                               {ok, State0 :: nova_http_handler:nova_http_state()} |
                               {stop, State0 :: nova_http_handler:nova_http_state()} |
                               {error, Reason :: term()}.
-pre_http_request(State = #{req := Req, secure := {Module, Function}}, _Options) ->
-    try Module:Function(Req) of
+pre_http_request(State = #{req := Req, secure := {Module, Function}, controller_data := ControllerData}, _Options) ->
+    try Module:Function(ControllerData#{req => Req}) of
         {true, AuthData} ->
-            {ok, State#{controller_data =>
-                            #{auth_data => AuthData}}};
+            {ok, State#{controller_data => ControllerData#{auth_data => AuthData}}};
         true ->
             {ok, State};
         false ->


### PR DESCRIPTION
Return existing controller data + auth_data

Unfortunately this is a breaking change with the req key, but I would like to argue that it is the correct way.

1. This change makes writing auth functions exactly like a controller. Making it easier to copy existing controller code.
2. This change is needed if using request_plugin and the security_plugin.

It could be possible to feature flag this with a config variable to make it backwards compatible.