### PR TITLE
added support for websocket push

### DIFF
--- a/src/nova_ws_handler.erl
+++ b/src/nova_ws_handler.erl
@@ -65,7 +65,7 @@ upgrade_ws(Module, Req, State, ControllerData) ->
 websocket_init(State = #{mod := Mod}) ->
     case erlang:function_exported(Mod, websocket_init, 1) of
         true ->
-            handle_ws(Mod, websocket_init, [], State);
+            handle_ws(Mod, websocket_init, [], State#{controller_data => #{ws_handler_process => self()}});
         _ ->
             {ok, State}
     end.


### PR DESCRIPTION
Hi, I added a reference to the websocket handler process in the controller data map used by the user defined ws handler. 
The ws_handler_process value is the process id of the websocket controller; it can be used as the destination of generic messages to implement push notifications to the clients.
