### PR TITLE
Make the `use_strict` option in routing be configurable by the user

### DIFF
--- a/guides/routing.md
+++ b/guides/routing.md
@@ -81,3 +81,11 @@ do_security(Req) ->
 ```
 
 This will cause nova to return a `401` status code for all requests not coming from my_domain.com
+
+
+## Configuration of error-detection in route-tree
+
+Since Nova 0.8.0 we are using `routing_tree` as underlying data structure to handle routes. `routing_tree` utilizes a radix-like tree structure to store the routing information
+and can also determine if a route already exists or creates a non-deterministic behaviour. The detection is turned off as default. This behaviour can be turned on by setting `{use_strict_routing, true}` setting for `nova` in your `sys.config`-file.
+
+*Note!* Be aware that the strict-mode is experimental and might cause false-positives, resulting in an exception when starting your application.

--- a/src/nova_router.erl
+++ b/src/nova_router.erl
@@ -33,7 +33,8 @@
 
 -spec compile(Apps :: [atom()]) -> host_tree().
 compile(Apps) ->
-    Dispatch = compile(Apps, routing_tree:new(#{use_strict => true, convert_to_binary => true}), #{}),
+    UseStrict = application:get_env(nova, use_strict_routing, false),
+    Dispatch = compile(Apps, routing_tree:new(#{use_strict => UseStrict, convert_to_binary => true}), #{}),
     ok = persistent_term:put(nova_dispatch, Dispatch),
     Dispatch.
 


### PR DESCRIPTION
This also sets the default to `false` which can be preferable before routing_tree have passed beta-stage.