### PR TITLE
Update documentation for `nova_plugin`

### DIFF
--- a/src/nova_basic_handler.erl
+++ b/src/nova_basic_handler.erl
@@ -19,15 +19,13 @@
 %% @doc
 %% Handler for JSON. It takes two different return objects:
 %%
-%% <options>
-%%   <option for="{json, JSON :: map()}"> returns the JSON encoded to the user.
+%%   {json, JSON :: map()} returns the JSON encoded to the user.
 %%     If the operation was a POST the HTTP-status code will be 201, otherwise
-%%     200.</option>
+%%     200.
 %%
-%%   <option for="{json, StatusCode :: integer(), Headers :: map(), JSON :: map()}"> Same
+%%   {json, StatusCode :: integer(), Headers :: map(), JSON :: map()} Same
 %%     operation as the above except you can set custom status code and custom
-%%     headers.</option>
-%% </options>
+%%     headers.
 %% @end
 %%--------------------------------------------------------------------
 -spec handle_json({json, JSON :: map()} | {json, StatusCode :: integer(), Headers :: map(), JSON :: map()},
@@ -62,20 +60,20 @@ handle_json({json, JSON}, ModFun, Req = #{method := Method}) ->
 %% If not another view is specified in options a view that corresponds to the controller will be
 %% rendered.
 %%
-%% <code title="Example of controller named 'app_main_controller.erl'">
+%%
 %% -module(my_first_controller).
 %% -compile(export_all).
 %%
 %% my_function(_Req) ->
 %%    {ok, []}.
-%% </code>
-%% The example above will then render the view named <icode>'app_main.dtl'</icode>
+%%
+%% The example above will then render the view named 'app_main.dtl'
 %%
 %% Options can be specified as follows:
 %%
-%% - <icode>view</icode> - Specifies if another view should be rendered instead of default one
+%% - view - Specifies if another view should be rendered instead of default one
 %%
-%% - <icode>headers</icode> - Custom headers
+%% - headers - Custom headers
 %% @end
 %%--------------------------------------------------------------------
 -spec handle_ok({ok, Variables :: erlydtl_vars()} | {ok, Variables :: erlydtl_vars(), Options :: map()},
@@ -102,7 +100,7 @@ handle_ok({ok, Variables, Options}, {Mod, _Func}, Req) ->
 %%--------------------------------------------------------------------
 %% @doc
 %% Handler for returning http status codes. There's three different ways one can
-%% return status code. The most basic case is <icode>{status, Status}</icode> where Status is
+%% return status code. The most basic case is {status, Status} where Status is
 %% the code that should be returned.
 %%
 %% If there's a need for additional headers to be sent along with the http code one can specify
@@ -142,8 +140,8 @@ handle_status({status, Status}, ModFun, State) when is_integer(Status) ->
 %%--------------------------------------------------------------------
 %% @doc
 %% Handles redirects. This will return a 302-status code with a location given
-%% by the user. Something like <icode>{redirect, "/login"}</icode> will send a
-%% 302 with <icode>location</icode> set to <icode>"/login"</icode>
+%% by the user. Something like {redirect, "/login"} will send a
+%% 302 with location set to "/login"
 %% @end
 %%-----------------------------------------------------------------
 -spec handle_redirect({redirect, Route :: list()}, ModFun :: mod_fun(),

--- a/src/nova_handlers.erl
+++ b/src/nova_handlers.erl
@@ -7,7 +7,7 @@
 %%% of a function of arity 4. We will show an example of this.
 %%%
 %%% If you implement the following module:
-%%% <code title="src/my_handler.erl">
+%%%
 %%% -module(my_handler).
 %%% -export([init/0,
 %%%          handle_console]).
@@ -21,18 +21,17 @@
 %%%    io:format("State: ~p~n", [State]),
 %%%    io:format(Format, Args),
 %%%    io:format("~n=====================~n", []),
-%%%    {ok, 200, #{}, <binary></binary>}.
-%%% </code>
+%%%    {ok, 200, #{}, EmptyBinary}.
 %%%
-%%% The <icode>init/0</icode> should be invoked from your applications <i>supervisor</i> and will register the module
-%%% <icode>my_handler</icode> as handler of the return type <icode>{console, Format, Args}</icode>. This means that you
-%%% can return this tuple in a controller which invokes <icode>my_handler:handle_console/4</icode>.
+%%% The init/0 should be invoked from your applications <i>supervisor</i> and will register the module
+%%% my_handler as handler of the return type {console, Format, Args}. This means that you
+%%% can return this tuple in a controller which invokes my_handler:handle_console/4.
 %%%
 %%% <b>A handler can return two different types</b>
 %%%
-%%% <icode>{ok, StatusCode, Headers, Body}</icode> - This will return a proper reply to the requester.
+%%% {ok, StatusCode, Headers, Body} - This will return a proper reply to the requester.
 %%%
-%%% <icode>{error, Reason}</icode> - This will render a 500 page to the user.
+%%% {error, Reason} - This will render a 500 page to the user.
 %%% @end
 %%% Created : 12 Feb 2020 by Niclas Axelsson <niclas@burbas.se>
 %%%-------------------------------------------------------------------

--- a/src/nova_plugin.erl
+++ b/src/nova_plugin.erl
@@ -3,18 +3,25 @@
 %%% @copyright (C) 2020, Niclas Axelsson
 %%% @doc
 %%% Plugins can be run at two different times; either in the beginning or at
-%% the end of a request. They can modify both the actual request or the nova-state.
-%% A plugin is implemented with the <icode>nova_plugin</icode> behaviour
-%%% and needs to implement three different functions: <icode>pre_request/2</icode>,
-%% <icode>post_request/2</icode> and <icode>plugin_info/0</icode>.
+%%% the end of a request. They can modify both the actual request or the nova-state.
+%%% A plugin is implemented with the nova_plugin behaviour
+%%% and needs to implement three different functions: pre_request/2,
+%%% post_request/2 and plugin_info/0.
 %%%
+%%% A plugin can return either {ok, NewState}, {break, NewState},
+%%% {stop, NewState}, {error, Reason}.
 %%%
+%%% {ok, NewState} will continue the normal execution with the NewState.
 %%%
+%%% {break, NewState} breaks the execution of the current plugin-chain. This means that
+%%% if a pre_request-plugin returns the break-statement the rest of the plugins in that chain will be skipped.
 %%%
-%%% To register the plugin above you have to call
-%%  <icode>nova_plugin:register_plugin(RequestType, http, example_plugin).</icode> in order
-%%% to run it. <icode>RequestType</icode> can either be <icode>pre_request</icode> or
-%%  <icode>post_request</icode>.
+%%% {stop, NewState} stops the execution. The plugin is responsible in this case for returning
+%%% a proper response to the client.
+%%%
+%%% {error, Reason} will stop the execution and call the nova_error plugin, resulting in a 500 response back
+%%% to the user. If debug mode is enabled the reason will be returned in the 500-response.
+%%%
 %%% @end
 %%% Created : 12 Feb 2020 by Niclas Axelsson <niclas@burbas.se>
 %%%-------------------------------------------------------------------

--- a/src/nova_sup.erl
+++ b/src/nova_sup.erl
@@ -26,9 +26,9 @@
 %% @doc
 %% Starts the supervisor
 %%
-%% @spec start_link() -> {ok, Pid} | ignore | {error, Error}
 %% @end
 %%--------------------------------------------------------------------
+-spec start_link() -> {ok, Pid :: pid()} | ignore | {error, Error :: any()}.
 start_link() ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
@@ -44,9 +44,6 @@ start_link() ->
 %% restart strategy, maximum restart intensity, and child
 %% specifications.
 %%
-%% @spec init(Args) -> {ok, {SupFlags, [ChildSpec]}} |
-%%                     ignore |
-%%                     {error, Reason}
 %% @end
 %%--------------------------------------------------------------------
 init([]) ->


### PR DESCRIPTION
This commit includes fixes for other modules where we used the `<icode>`-tag which is not supported by ex_docs. It also describes how a plugin works and what to expect from the different return-objects.