### PR TITLE
This will add Prefix to Path so websocket can have prefixes.

### DIFF
--- a/src/nova_router.erl
+++ b/src/nova_router.erl
@@ -280,7 +280,8 @@ parse_url(Host,
                                     plugins = Value#nova_handler_value.plugins,
                                     secure = Secure},
     ?DEBUG("Adding ws: ~s for app: ~p", [Path, App]),
-    CompiledPaths = insert(Host, Path, '_', Value0, Tree),
+    RealPath = string:concat(Prefix, Path),
+    CompiledPaths = insert(Host, RealPath, '_', Value0, Tree),
     parse_url(Host, Tl, Prefix, Value, CompiledPaths);
 parse_url(Host, [{Path, {Mod, Func}}|Tl], Prefix, Value, Tree) ->
     parse_url(Host, [{Path, {Mod, Func}, #{}}|Tl], Prefix, Value, Tree).


### PR DESCRIPTION
close #129 

Issue wasn't security it was wrong path in routing tree.