### PR TITLE
Use logger and formatters instead of hard-coding the logging-format

### DIFF
--- a/include/nova.hrl
+++ b/include/nova.hrl
@@ -9,21 +9,16 @@
 -define(TERM_BOLD, "\033[1m").
 -define(TERM_RESET, "\033[m").
 
--define(MOD_INFO, ?TERM_BOLD ++ "[" ++ erlang:atom_to_list(?MODULE) ++ "] " ++ ?TERM_RESET).
+-define(DEBUG(M), ?LOG(debug, M)).
+-define(DEBUG(M, Meta), ?LOG(debug, M, Meta)).
+-define(INFO(M), ?LOG(info, M)).
+-define(INFO(M, Meta), ?LOG(info, M, Meta)).
+-define(NOTICE(M), ?LOG(notice, M)).
+-define(NOTICE(M, Meta), ?LOG(notice, M, Meta)).
+-define(WARNING(M), ?LOG(warning, M)).
+-define(WARNING(M, Meta), ?LOG(warning, M, Meta)).
+-define(ERROR(M), ?LOG(error, M)).
+-define(ERROR(M, Meta), ?LOG(error, M, Meta)).
 
--define(DEBUG(M), ?LOG(debug, ?MOD_INFO ++ ?TERM_BLUE ++ M ++ ?TERM_RESET)).
--define(DEBUG(M, Meta), ?LOG(debug, ?MOD_INFO ++ ?TERM_BLUE ++ M ++ ?TERM_RESET, Meta)).
--define(INFO(M), ?LOG(info, ?MOD_INFO ++ ?TERM_GREEN ++ M ++ ?TERM_RESET)).
--define(INFO(M,Meta), ?LOG(info, ?MOD_INFO ++ ?TERM_GREEN ++ M ++ ?TERM_RESET, Meta)).
--define(NOTICE(M), ?LOG(notice, ?MOD_INFO ++ ?TERM_GREEN ++ M ++ ?TERM_RESET)).
--define(NOTICE(M,Meta), ?LOG(notice, ?MOD_INFO ++ ?TERM_GREEN ++ M ++ ?TERM_RESET, Meta)).
--define(WARNING(M), ?LOG(warning, ?MOD_INFO ++ ?TERM_YELLOW ++ M ++ ?TERM_RESET)).
--define(WARNING(M,Meta), ?LOG(warning, ?MOD_INFO ++ ?TERM_YELLOW ++ M ++ ?TERM_RESET, Meta)).
--define(ERROR(M), ?LOG(error, ?MOD_INFO ++ ?TERM_RED ++ M ++ ?TERM_RESET)).
--define(ERROR(M,Meta), ?LOG(error, ?MOD_INFO ++ ?TERM_RED ++ M ++ ?TERM_RESET, Meta)).
-
-%% Meta levels
--define(DEPRECATION(M), ?LOG(warning, ?TERM_YELLOW ++ ?TERM_BOLD ++ "DEPRECATION WARNING! " ++ ?TERM_RESET ++ ?TERM_YELLOW ++ M ++ ?TERM_RESET)).
--define(DEPRECATED(M), ?LOG(error, ?TERM_RED ++ ?TERM_BOLD ++ "DEPRECATION ERROR!!! " ++ ?TERM_RESET ++ ?TERM_RED ++ M ++ ?TERM_RESET)).
 
 -endif.

--- a/src/nova_router.erl
+++ b/src/nova_router.erl
@@ -21,6 +21,8 @@
          render_status_page/2,
          render_status_page/3,
          render_status_page/5,
+
+         %% Expose the router-callback
          routes/1
         ]).
 
@@ -183,7 +185,8 @@ parse_url(Host,
                 case {filelib:is_file(LocalPath), filelib:is_file(PrivPath)} of
                     {false, false} ->
                         %% No dir nor file
-                        logger:warning(#{"reason" => "Could not find local path for the given resource", "local_path" => LocalPath, "remote_path" => RemotePath}),
+                        logger:warning(#{"reason" => "Could not find local path for the given resource",
+                                         "local_path" => LocalPath, "remote_path" => RemotePath}),
                         not_found;
                     {true, false} ->
                         {file, LocalPath};
@@ -220,7 +223,8 @@ parse_url(Host,
                 case {filelib:is_file(LocalPath), filelib:is_file(PrivPath)} of
                     {false, false} ->
                         %% No dir nor file
-                        logger:warning(#{"reason" => "Could not find local path for the given resource", "local_path" => LocalPath, "remote_path" => RemotePath}),
+                        logger:warning(#{"reason" => "Could not find local path for the given resource",
+                                         "local_path" => LocalPath, "remote_path" => RemotePath}),
                         not_found;
                     {true, false} ->
                         {file, LocalPath};

--- a/src/nova_router.erl
+++ b/src/nova_router.erl
@@ -86,7 +86,7 @@ execute(Req = #{host := Host, path := Path, method := Method}, Env) ->
                  }
             };
         Error ->
-            ?ERROR("Got error: ~p", [Error]),
+            logger:error(#{"reason" => "Unexpected return from routing_tree:lookup/4", "return_object" => Error}),
             render_status_page(Host, 404, #{error => Error}, Req, Env)
     end.
 
@@ -113,12 +113,17 @@ compile([App|Tl], Dispatch, Options) ->
     %% Fetch the router-module for this application
     Router = erlang:list_to_atom(erlang:atom_to_list(App) ++ "_router"),
     Env = nova:get_environment(),
-    Routes = Router:routes(Env),
-    Options1 = Options#{app => App},
+    case erlang:function_exported(Router, routes, 1) of
+        true ->
+            Routes = Router:routes(Env),
+            Options1 = Options#{app => App},
 
-    {ok, Dispatch1, Options2} = compile_paths(Routes, Dispatch, Options1),
-    compile(Tl, Dispatch1, Options2).
-
+            {ok, Dispatch1, Options2} = compile_paths(Routes, Dispatch, Options1),
+            compile(Tl, Dispatch1, Options2);
+        _ ->
+            logger:warning(#{"app" => App, "msg" => "routes-module not found or not exposing the routes/1 function"}),
+            compile(Tl, Dispatch, Options)
+    end.
 
 compile_paths([], Dispatch, Options) -> {ok, Dispatch, Options};
 compile_paths([RouteInfo|Tl], Dispatch, Options) ->
@@ -178,7 +183,7 @@ parse_url(Host,
                 case {filelib:is_file(LocalPath), filelib:is_file(PrivPath)} of
                     {false, false} ->
                         %% No dir nor file
-                        ?WARNING("Could not find local path \"~p\" given for path \"~p\"", [LocalPath, RemotePath]),
+                        logger:warning(#{"reason" => "Could not find local path for the given resource", "local_path" => LocalPath, "remote_path" => RemotePath}),
                         not_found;
                     {true, false} ->
                         {file, LocalPath};
@@ -215,7 +220,7 @@ parse_url(Host,
                 case {filelib:is_file(LocalPath), filelib:is_file(PrivPath)} of
                     {false, false} ->
                         %% No dir nor file
-                        ?WARNING("Could not find local path \"~p\" given for path \"~p\"", [LocalPath, RemotePath]),
+                        logger:warning(#{"reason" => "Could not find local path for the given resource", "local_path" => LocalPath, "remote_path" => RemotePath}),
                         not_found;
                     {true, false} ->
                         {file, LocalPath};
@@ -235,7 +240,7 @@ parse_url(Host,
                 secure = Secure
                },
 
-    ?DEBUG("Adding route: ~s for app: ~p", [string:concat(Prefix, RemotePath), App]),
+    logger:debug(#{"action" => "Adding route", "route" => string:concat(Prefix, RemotePath), "app" => App}),
     Tree0 = insert(Host, string:concat(Prefix, RemotePath), '_', Value0, Tree),
     parse_url(Host, Tl, Prefix, Value, Tree0);
 
@@ -263,7 +268,7 @@ parse_url(Host,
                                 function = Func
                                }
                       end,
-                  ?DEBUG("Adding route: ~s for app: ~p", [RealPath, App]),
+                  logger:debug(#{"action" => "Adding route", "route" => RealPath, "app" => App}),
                   insert(Host, RealPath, BinMethod, Value0, Tree0)
           end, Tree, Methods),
     parse_url(Host, Tl, Prefix, Value, CompiledPaths);
@@ -277,7 +282,7 @@ parse_url(Host,
                                     arguments = #{module => Mod},
                                     plugins = Value#nova_handler_value.plugins,
                                     secure = Secure},
-    ?DEBUG("Adding ws: ~s for app: ~p", [Path, App]),
+    logger:debug(#{"action" => "Adding route", "protocol" => "ws", "route" => Path, "app" => App}),
     RealPath = string:concat(Prefix, Path),
     CompiledPaths = insert(Host, RealPath, '_', Value0, Tree),
     parse_url(Host, Tl, Prefix, Value, CompiledPaths);
@@ -333,11 +338,10 @@ insert(Host, Path, Combinator, Value, Tree) ->
         Tree0 -> Tree0
     catch
         throw:Exception ->
-            ?ERROR("Error when inserting route ~s : ~s", [Combinator, Path]),
-            ?DEBUG("Was called as: routing_tree:insert(~p, ~p, ~p, ~p, ~p)", [Host, Path, Combinator, Value, Tree]),
+            logger:error(#{"reason" => "Error when inserting route", "route" => Path, "combinator" => Combinator}),
             throw(Exception);
         Type:Exception ->
-            ?ERROR("Error type ~p with exception ~p", [Type, Exception]),
+            logger:error(#{"reason" => "Unexpected exit", "type" => Type, "exception" => Exception}),
             throw(Exception)
     end.
 
@@ -377,7 +381,7 @@ persistent_get(Key) ->
         true ->
             persistent_term:get(Key);
         _ ->
-            ?WARNING("Called persistent_get/1 without option use_persistent_term is set to true"),
+            logger:warning(#{"reason" => "Called persistent_get/1 without option use_persistent_term set to true"}),
             throw({unsupported_operation, persistent_get})
     end.
 

--- a/src/plugins/nova_correlation_plugin.erl
+++ b/src/plugins/nova_correlation_plugin.erl
@@ -7,6 +7,8 @@
 
 pre_request(Req, _) ->
     UUID = uuid:uuid_to_string(uuid:get_v4()),
+    %% Update the loggers metadata with correlation-id
+    logger:update_process_metadata(#{<<"correlation-id">> => UUID}),
     Req1 = cowboy_req:set_resp_header(<<"X-Correlation-ID">>, UUID, Req),
     {ok, Req1}.
 
@@ -15,9 +17,9 @@ post_request(Req, _) ->
 
 plugin_info() ->
     {
-     <<"nova_correlation_plugin">>, 
-     <<"0.1.0">>, 
+     <<"nova_correlation_plugin">>,
+     <<"0.1.0">>,
      <<"Nova team <info@novaframework.org">>,
-     <<"Add X-Correlation-ID headers to response">>, 
+     <<"Add X-Correlation-ID headers to response">>,
      []
     }.


### PR DESCRIPTION
This branch removes the custom, hard-coded logging we have in place today in favour for a user-defined logger-instruction. 

There's also a related commit in the rebar3_nova repository (https://github.com/novaframework/rebar3_nova/pull/17) which adds a basic structure for this.

Closes #149 