### PR TITLE
Better HTTP-status error handling

### DIFF
--- a/src/controllers/nova_error_controller.erl
+++ b/src/controllers/nova_error_controller.erl
@@ -4,18 +4,39 @@
          server_error/1
         ]).
 
-not_found(_Req) ->
-    Variables = #{status => "Could not find the page you were looking for",
-                  title => "404 Not found",
-                  message => "We could not find the page you were looking for"},
-    {ok, Body} = nova_error_dtl:render(Variables),
-    {status, 404, #{}, Body}.
+not_found(Req) ->
+    %% Check the accept-headers
+    case cowboy_req:header(<<"accept">>, Req) of
+        <<"application/json">> ->
+            %% Render a json response
+            Json = #{message => "Resource not found"},
+            {status, 404, #{<<"content-type">> => <<"application/json">>}, json:encode(Json, [maps, binary])};
+        _ ->
+            %% Just assume HTML
+            Variables = #{status => "Could not find the page you were looking for",
+                          title => "404 Not found",
+                          message => "We could not find the page you were looking for"},
+            {ok, Body} = nova_error_dtl:render(Variables),
+            {status, 404, #{<<"content-type">> => <<"application/json">>}, Body}
+    end.
 
-server_error(#{crash_info := #{stacktrace := Stacktrace, class := Class, reason := Reason}}) ->
+server_error(#{crash_info := #{stacktrace := Stacktrace, class := Class, reason := Reason}} = Req) ->
     Variables = #{status => "Internal Server Error",
                   title => "500 Internal Server Error",
                   message => "Something internal crashed. Please take a look!",
                   extra_msg => io_lib:format("~p, ~p", [Class, Reason]),
-                  stacktrace => Stacktrace}, #{view => nova_error},
-    {ok, Body} = nova_error_dtl:render(Variables),
-    {status, 500, #{}, Body}.
+                  stacktrace => Stacktrace},
+
+    case nova:get_environment() of
+        dev ->
+            %% We do show a proper error response
+            case cowboy_req:header(<<"accept">>, Req) of
+                <<"application/json">> ->
+                    {status, 500, #{<<"content-type">> => <<"application/json">>}, json:encode(Variables)};
+                _ ->
+                    {ok, Body} = nova_error_dtl:render(Variables),
+                    {status, 500, #{<<"content-type">> => <<"text/html">>}, Body}
+            end;
+        _ ->
+            {status, 500}
+    end.


### PR DESCRIPTION
We now respect the `accept`-header and send a proper return object. For 500-errors we only send the stacktrace iff `{nova, environment, Val}`-config is set to `dev`.

Closes #142