### PR TITLE
Better error reporting

### DIFF
--- a/src/controllers/nova_error_controller.erl
+++ b/src/controllers/nova_error_controller.erl
@@ -6,8 +6,6 @@
 
 not_found(Req) ->
     %% Check the accept-headers
-
-
     case cowboy_req:header(<<"accept">>, Req) of
         <<"application/json">> ->
             %% Render a json response
@@ -20,7 +18,7 @@ not_found(Req) ->
                           title => "404 Not found",
                           message => "We could not find the page you were looking for"},
             {ok, Body} = nova_error_dtl:render(Variables),
-            {status, 404, #{<<"content-type">> => <<"application/json">>}, Body}
+            {status, 404, #{<<"content-type">> => <<"text/html">>}, Body}
     end.
 
 server_error(#{crash_info := #{stacktrace := Stacktrace, class := Class, reason := Reason}} = Req) ->

--- a/src/controllers/nova_error_controller.erl
+++ b/src/controllers/nova_error_controller.erl
@@ -21,11 +21,31 @@ not_found(Req) ->
             {status, 404, #{<<"content-type">> => <<"text/html">>}, Body}
     end.
 
+server_error(#{crash_info := #{status_code := StatusCode} = CrashInfo} = Req) ->
+    Variables = #{status => maps:get(status, CrashInfo, undefined),
+                  title => maps:get(title, CrashInfo, undefined),
+                  message => maps:get(message, CrashInfo, undefined),
+                  extra_msg => maps:get(extra_msg, CrashInfo, undefined),
+                  stacktrace => maps:get(stacktrace, CrashInfo, undefined)},
+    case application:get_env(nova, render_error_pages, true) of
+        true ->
+            case cowboy_req:header(<<"accept">>, Req) of
+                <<"application/json">> ->
+                    {ok, JsonLib} = nova:get_env(json_lib, thoas),
+                    Json = erlang:apply(JsonLib, encode, [Variables]),
+                    {status, StatusCode, #{<<"content-type">> => <<"application/json">>}, Json};
+                _ ->
+                    {ok, Body} = nova_error_dtl:render(Variables),
+                    {status, StatusCode, #{<<"content-type">> => <<"text/html">>}, Body}
+            end;
+        _ ->
+            {status, StatusCode}
+    end;
 server_error(#{crash_info := #{stacktrace := Stacktrace, class := Class, reason := Reason}} = Req) ->
     Variables = #{status => "Internal Server Error",
                   title => "500 Internal Server Error",
                   message => "Something internal crashed. Please take a look!",
-                  extra_msg => io_lib:format("~p, ~p", [Class, Reason]),
+                  extra_msg => io_lib:format("Class: ~p<br /> Reason: ~p", [Class, Reason]),
                   stacktrace => Stacktrace},
 
     case nova:get_environment() of

--- a/src/nova_handler.erl
+++ b/src/nova_handler.erl
@@ -37,24 +37,37 @@ execute(Req, Env = #{cowboy_handler := Handler, arguments := Arguments}) ->
             render_response(Req#{crash_info => Payload}, Env, 500)
     end;
 execute(Req, Env = #{module := Module, function := Function}) ->
-    try erlang:apply(Module, Function, [Req]) of
-        RetObj ->
-            case nova_handlers:get_handler(element(1, RetObj)) of
-                {ok, Callback} ->
-                    {ok, Req0} = Callback(RetObj, {Module, Function}, Req),
-                    render_response(Req0, Env);
-                {error, not_found} ->
-                    logger:error(#{msg => "Controller returned unsupported result", controller => Module,
-                                   function => Function, return => RetObj})
-            end
-    catch Class:Reason:Stacktrace ->
-            logger:error(#{msg => "Controller crashed", class => Class, reason => Reason, stacktrace => Stacktrace}),
-            terminate(Reason, Req, Module),
-            %% Build the payload object
+    case erlang:function_exported(Module, Function, 1) of
+        true ->
+            try erlang:apply(Module, Function, [Req]) of
+                RetObj ->
+                    case nova_handlers:get_handler(element(1, RetObj)) of
+                        {ok, Callback} ->
+                            {ok, Req0} = Callback(RetObj, {Module, Function}, Req),
+                            render_response(Req0, Env);
+                        {error, not_found} ->
+                            logger:error(#{msg => "Controller returned unsupported result", controller => Module,
+                                           function => Function, return => RetObj})
+                    end
+            catch Class:Reason:Stacktrace ->
+                    logger:error(#{msg => "Controller crashed", class => Class, reason => Reason, stacktrace => Stacktrace}),
+                    terminate(Reason, Req, Module),
+                    %% Build the payload object
+                    Payload = #{status_code => 500,
+                                stacktrace => Stacktrace,
+                                class => Class,
+                                reason => Reason},
+                    render_response(Req#{crash_info => Payload}, Env, 500)
+            end;
+        _ ->
+            logger:error(#{msg => "Could not find controller", controller => Module, function => io_lib:format("~s/1", [Function])}),
             Payload = #{status_code => 500,
-                        stacktrace => Stacktrace,
-                        class => Class,
-                        reason => Reason},
+                        status => "Problems with application",
+                        stacktrace => [{Module, Function, 1}],
+                        title => "Woops. It seems like you have a problem with your application!",
+                        extra_msg => "Nova could not find your controller:function. Pleae check your spelling and/or that the module" ++
+                            " have been properly loaded. "
+                       },
             render_response(Req#{crash_info => Payload}, Env, 500)
     end.
 

--- a/src/nova_handler.erl
+++ b/src/nova_handler.erl
@@ -50,7 +50,10 @@ execute(Req, Env = #{module := Module, function := Function}) ->
                                            function => Function, return => RetObj})
                     end
             catch Class:Reason:Stacktrace ->
-                    logger:error(#{msg => "Controller crashed", class => Class, reason => Reason, stacktrace => Stacktrace}),
+                    logger:error(#{msg => "Controller crashed",
+                                   class => Class,
+                                   reason => Reason,
+                                   stacktrace => Stacktrace}),
                     terminate(Reason, Req, Module),
                     %% Build the payload object
                     Payload = #{status_code => 500,
@@ -60,13 +63,16 @@ execute(Req, Env = #{module := Module, function := Function}) ->
                     render_response(Req#{crash_info => Payload}, Env, 500)
             end;
         _ ->
-            logger:error(#{msg => "Could not find controller", controller => Module, function => io_lib:format("~s/1", [Function])}),
+            logger:error(#{msg => "Could not find controller",
+                           controller => Module,
+                           function => io_lib:format("~s/1", [Function])}),
             Payload = #{status_code => 500,
                         status => "Problems with application",
                         stacktrace => [{Module, Function, 1}],
                         title => "Woops. It seems like you have a problem with your application!",
-                        extra_msg => "Nova could not find your controller:function. Pleae check your spelling and/or that the module" ++
-                            " have been properly loaded. "
+                        extra_msg => "Nova could not find your controller:function.
+                                      Pleae check your spelling and/or that the module" ++
+                                     " have been properly loaded. "
                        },
             render_response(Req#{crash_info => Payload}, Env, 500)
     end.

--- a/src/views/nova_error.dtl
+++ b/src/views/nova_error.dtl
@@ -119,16 +119,16 @@
       <span>
         <h1>{{ title }}</h1>
         {{ message }}
-        {% if stacktrace %}
+        {% if extra_msg %}
         <pre>
-          {% if extra_msg %}
-          {{ extra_msg }}
-          {% endif %}
+          {{ extra_msg|safe }}
+          {% if stacktrace %}
           <code class="erlang">
             {% for error in stacktrace %}
             {{ error }}
             {% endfor %}
           </code>
+          {% endif %}
         </pre>
         {% endif %}
       </span>


### PR DESCRIPTION
This adds a small check to see if the controller actually have the function exported. If not Nova will generate an error. Also fixed a bug with 404 pages not returning the correct `content-type` header.

Not sure how expensive the `erlang:function_exported/3` is, but think it's small enough to be okay to use here.

Closes #174 