### PR TITLE
Improve guides-plugins.md section

### DIFF
--- a/guides/plugins.md
+++ b/guides/plugins.md
@@ -27,9 +27,17 @@ plugin_info() ->
 
 This plugin injects a UUID into the headers.
 
-A good example of a very useful plugin is the decode_json_body.When we are developing a HTTP web api  using json as the data format, we need the framework to
+
+Adding a plugin
+
+Example:
+A good example of a very useful plugin is the `decode_json_body` one. When we are developing a HTTP web api using json as the data format, we need the framework to
 decode our message so that we can process it.
-We add this plugin by editing the  `rebar.config` file like below:
+We can add this plugin by editing the  `rebar.config` file like below:
+
+
+**rebar.config**
+
 
  ```
      {nova, [
@@ -45,4 +53,19 @@ We add this plugin by editing the  `rebar.config` file like below:
                    ]}
         ]}
  ```
- We have added our plugin in the `plugins` section.
+ We have added our plugin in the `plugins` section. As we can see this is a `pre_request` plugin since it processes and decodes the message to json format 
+ before we can actually use it in our nova application endpoints.
+
+Usage:
+
+**controller**
+
+```
+-module(test_controller).
+-behaviour(nova_router).
+-export([increment/1]).
+
+increment(#{json := #{<<"id">> := Id, <<"value">> := Value}})->
+    {json,200,#{},#{<<"id">> => Id , <<"received">> => Value, <<"increment">> => Value+1}}.
+
+```

--- a/guides/plugins.md
+++ b/guides/plugins.md
@@ -26,3 +26,23 @@ plugin_info() ->
 ```
 
 This plugin injects a UUID into the headers.
+
+A good example of a very useful plugin is the decode_json_body.When we are developing a HTTP web api  using json as the data format, we need the framework to
+decode our message so that we can process it.
+We add this plugin by editing the  `rebar.config` file like below:
+
+ ```
+     {nova, [
+         {environment, dev},
+         {cowboy_configuration, #{
+                                  port => 8080
+                                 }},
+         {dev_mode, true},
+         {bootstrap_application, chatapp}, 
+         {plugins, [
+                    {pre_request, nova_request_plugin, #{parse_bindings => true}},
+                    {pre_request, nova_request_plugin, #{decode_json_body => true}} -- here
+                   ]}
+        ]}
+ ```
+ We have added our plugin in the `plugins` section.


### PR DESCRIPTION
I added a section explaining how to add new plugin, in this case the `decode_json_body` one since i think its critical for developers to have it already when developing HTTP web apis.
I have also added a small example on how an endpoint using json would look like.

I know there are already examples but i think this is really important for new people to know where to add stuff.