### PR TITLE
Fallback controller

### DIFF
--- a/guides/controllers.md
+++ b/guides/controllers.md
@@ -107,6 +107,40 @@ Sends a file using sendfile. This uses cowboys sendfile functionality and more i
 
 Sends a temporary redirect (HTTP status code 302) for the specified path to requester.
 
+
+## Fallback controllers
+
+[Phoenix](https://www.phoenixframework.org) have a really useful feature which they call [action_fallback]( https://hexdocs.pm/phoenix/Phoenix.Controller.html#action_fallback/1). We thought it would be a good addition to Nova to include somthing similar and therefore the `fallback_controller` was introduced. If a controller returns an invalid/unhandled result the fallback controller gets invoked and can take action on the payload. It's good for separating error-handling from the controllers. A fallback controller is set by setting the `fallback_controller` attribute with the module name of the fallback controller.
+
+The following example shows how a controller defines a fallback
+
+```
+-module(my_main_controller).
+-export([
+    error_example/1
+]).
+-fallback_controller(my_fallback_controller).
+
+error_example(_Req) ->
+    %% Since {error, ...} is not a valid handler the fallback-controller will be invoked
+    {error, example_error}.
+```
+
+A fallback controller have one function exposed; `resolve/2` which returnes a handler like for regular controllers in order to return the response to client. If we take the previous example and try and build a fallback controller for it:
+
+```
+-module(my_fallback_controller).
+-export([
+    resolve/2
+]).
+
+resolve(Req, {error, example_error}) ->
+  {status, 400}.
+```
+
+
+
+
 ## Plugins
 
 Plugins is part of the Nova core and can be executed both before and after the execution of a controller. They can both terminate a request early (Like the *request plugin* does) or transform data into another structure (*json plugin*). Plugins can be defined in two different places; *Global* plugins is defined in the *sys.config* file and will be executed for every incoming request. If a plugin only should be executed for a limited set of endpoints it can be defined in the router-file for that specific application (These we call *local plugins*).

--- a/src/nova_handler.erl
+++ b/src/nova_handler.erl
@@ -97,7 +97,8 @@ execute_fallback(Module, Req, Response, Env) ->
                         status => <<"Problems with controller">>,
                         stacktrace => [{nova_handler, execute_fallback, 4}],
                         title => <<"Controller returned unsupported data">>,
-                        extra_msg => list_to_binary(io_lib:format("Controller returned unsupported data: ~p", [Response]))},
+                        extra_msg => list_to_binary(io_lib:format("Controller returned unsupported data: ~p",
+                                                                  [Response]))},
             render_response(Req#{crash_info => Payload}, Env, 500);
         [FallbackModule] ->
             case erlang:function_exported(FallbackModule, resolve, 2) of
@@ -108,7 +109,9 @@ execute_fallback(Module, Req, Response, Env) ->
                     Payload = #{status_code => 500,
                                 status => <<"Problems with fallback-controller">>,
                                 title => <<"Fallback controller does not have a valid resolve/2 function">>,
-                                extra_msg => list_to_binary(io_lib:format("Fallback controller ~s does not have a valid resolve/2 function", [FallbackModule]))},
+                                extra_msg => list_to_binary(io_lib:format("Fallback controller ~s does not have "
+                                                                          ++ "a valid resolve/2 function",
+                                                                          [FallbackModule]))},
                     render_response(Req#{crash_info => Payload}, Env, 500)
             end
     end.


### PR DESCRIPTION
Phoenix have a very neat way of handling non-expected results of a controller via a *fallback controller* (https://hexdocs.pm/phoenix/Phoenix.Controller.html#action_fallback/1). This commit includes a similar way of handling this.

A fallback controller is defined by setting the attribute `fallback_controller` in a controller. If a non-expected result is returned from the controller then the fallback_controllers `resolve/2` function is called with the arguments `Req :: cowboy_req(), ControllerOutput :: any()` where the ControllerOutput is result of executing the controller.

There's a few things to fix before we can merge this PR:

- [x] Add documentation on how to use fallback controllers
- [x] Ensure that modules loads in releases (I had some problems with this so it might be a real issue)
- [x] Write proper specs for the introduced functions