### PR TITLE
fix: nova_watcher and static files

### DIFF
--- a/src/nova_handler.erl
+++ b/src/nova_handler.erl
@@ -35,7 +35,7 @@ execute(Req, Env = #{cowboy_handler := Handler, arguments := Arguments}) ->
                         class => Class,
                         reason => Reason},
             ?LOG_ERROR(#{msg => <<"Controller crashed">>, class => Class, reason => Reason, stacktrace => Stacktrace}),
-            render_response(Req#{crash_info => Payload}, Env, 500)
+            render_response(Req#{crash_info => Payload}, maps:remove(cowboy_handler, Env), 404)
     end;
 execute(Req, Env = #{module := Module, function := Function}) ->
     %% Ensure that the module exists and have the correct function exported

--- a/src/nova_watcher.erl
+++ b/src/nova_watcher.erl
@@ -134,7 +134,7 @@ handle_cast({async, Application, Cmd, Args, Options}, State = #state{process_ref
     %% Set working directory
     file:set_cwd(Workdir),
     ArgList = string:join(Args, " "),
-    Port = erlang:open_port({spawn, Cmd ++ " " ++ ArgList}, []),
+    Port = erlang:open_port({spawn, Cmd ++ " " ++ ArgList}, [use_stdio, {line, 1024}, stderr_to_stdout]),
     ?LOG_NOTICE(#{action => <<"Started async command">>, command => Cmd, arguments => ArgList}),
     {noreply, State#state{process_refs = [Port|ProcessRefs]}};
 handle_cast(_Request, State) ->
@@ -152,7 +152,14 @@ handle_cast(_Request, State) ->
                          {noreply, NewState :: term(), hibernate} |
                          {stop, Reason :: normal | term(), NewState :: term()}.
 handle_info({ProcessRef, {data, Data}}, State) ->
-    ?LOG_DEBUG(#{action => <<"Received data from async command">>, data => Data, cmd_pid => ProcessRef}),
+    Msg = case Data of
+	      {eol, Text} -> Text;
+	      _ -> Data
+	  end,
+    case nova:get_environment() of
+	dev -> io:format("~s~n", [Msg]);
+	_ -> ok %% Ignore the output
+    end,
     {noreply, State};
 handle_info({'EXIT', Ref, Reason}, State = #state{process_refs = Refs}) ->
     %% Remove the port from our list

--- a/src/nova_watcher.erl
+++ b/src/nova_watcher.erl
@@ -153,12 +153,12 @@ handle_cast(_Request, State) ->
                          {stop, Reason :: normal | term(), NewState :: term()}.
 handle_info({ProcessRef, {data, Data}}, State) ->
     Msg = case Data of
-	      {eol, Text} -> Text;
-	      _ -> Data
-	  end,
+              {eol, Text} -> Text;
+              _ -> Data
+          end,
     case nova:get_environment() of
-	dev -> io:format("~s~n", [Msg]);
-	_ -> ok %% Ignore the output
+        dev -> io:format(user, "~s~n", [Msg]);
+        _ -> ok %% Ignore the output
     end,
     {noreply, State};
 handle_info({'EXIT', Ref, Reason}, State = #state{process_refs = Refs}) ->


### PR DESCRIPTION
This contains one fix for nova_watcher that fixes the output messages coming from the sub-process.

It also contains bug fix for when nova got into an infinite loop when accessing a file that did not exist.

Novas error_controller was also updated to handle the `accept` header in a proper manner.