### PR TITLE
feat: Dynamically enabled stacktraces

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -23,6 +23,7 @@ Following parameters should be defined under the `nova`-key in your *sys.config*
 | Key | Description | Value |
 |-----|-------------|-------|
 | `use_persistent_term` | Use `persistent_term` module to store routing tree | `boolean()` |
+| `use_stacktrace` | If Nova should include stacktrace in error-pages | `boolean()` |
 | `render_error_pages` | If Nova should render error-pages for HTML-request | `boolean()` |
 | `use_sessions` | Turn off/on support for sessions | `boolean()` |
 | `session_manager` | Specifify a module to use as the session manager. Defaults to `nova_session_ets` | `atom()` |

--- a/include/nova_internals.hrl
+++ b/include/nova_internals.hrl
@@ -1,6 +1,0 @@
-%% If USE_STACKTRACE is enabled then we return stacktraces
--ifndef(USE_STACKTRACES).
--define(CATCH_CLAUSE(T, R, S), T:R -> S = not_enabled,).
--else.
--define(CATCH_CLAUSE(T, R, S), T:R:S ->).
--endif.

--- a/src/controllers/nova_error_controller.erl
+++ b/src/controllers/nova_error_controller.erl
@@ -54,7 +54,8 @@ server_error(#{crash_info := #{status_code := StatusCode} = CrashInfo} = Req) ->
         _ ->
             {status, StatusCode}
     end;
-server_error(#{crash_info := #{stacktrace := Stacktrace, class := Class, reason := Reason}} = Req) ->
+server_error(#{crash_info := #{class := Class, reason := Reason}} = Req) ->
+    Stacktrace = maps:get(stacktrace, Req, []),
     Variables = #{status => "Internal Server Error",
                   title => "500 Internal Server Error",
                   message => "Something internal crashed. Please take a look!",
@@ -81,7 +82,7 @@ server_error(#{crash_info := #{stacktrace := Stacktrace, class := Class, reason 
 
 
 format_stacktrace(not_enabled) ->
-    logger:warning("Stacktrace disabled. If you want stacktrace enabled set {erl_opts, [{d,'USE_STACKTRACES'}]} in your rebar.config."),
+    logger:warning("Stacktrace disabled. If you want to enable stacktraces call nova:stracktrace(true) or update your sys.config - Read more in the docs"),
     [];
 format_stacktrace([]) -> [];
 format_stacktrace([{Mod, Func, Arity, [{file, File}, {line, Line}]}|Tl]) ->

--- a/src/nova.erl
+++ b/src/nova.erl
@@ -11,7 +11,7 @@
          get_environment/0,
          get_env/2,
          set_env/2,
-         stacktrace/1
+         use_stacktrace/1
         ]).
 
 -type state() :: any().
@@ -89,11 +89,12 @@ set_env(Key, Value) ->
 %%--------------------------------------------------------------------
 %% @doc
 %% Enables or disables stacktraces. This is a global setting and
-%% affects all requests.
+%% affects all requests. If stacktraces are enabled, nova will
+%% try to print a stacktrace when an exception is thrown.
 %% @end
 %%--------------------------------------------------------------------
--spec stacktrace(Enable :: boolean()) -> ok.
-stacktrace(true) ->
+-spec use_stacktrace(Enable :: boolean()) -> ok.
+use_stacktrace(true) ->
     persistent_term:put(nova_use_stacktrace, true);
-stacktrace(_) ->
+use_stacktrace(_) ->
     persistent_term:erase(nova_use_stacktrace).

--- a/src/nova.erl
+++ b/src/nova.erl
@@ -10,7 +10,8 @@
          get_apps/0,
          get_environment/0,
          get_env/2,
-         set_env/2
+         set_env/2,
+         stacktrace/1
         ]).
 
 -type state() :: any().
@@ -83,3 +84,16 @@ set_env(Key, Value) ->
         _ ->
             {error, main_app_not_found}
     end.
+
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Enables or disables stacktraces. This is a global setting and
+%% affects all requests.
+%% @end
+%%--------------------------------------------------------------------
+-spec stacktrace(Enable :: boolean()) -> ok.
+stacktrace(true) ->
+    persistent_term:put(nova_use_stacktrace, true);
+stacktrace(_) ->
+    persistent_term:erase(nova_use_stacktrace).

--- a/src/nova_sup.erl
+++ b/src/nova_sup.erl
@@ -99,7 +99,7 @@ setup_cowboy(Configuration) ->
             Host0 = inet:ntoa(Host),
             CowboyVersion = get_version(cowboy),
             NovaVersion = get_version(nova),
-            UseStacktrace = application:get(nova, use_stacktrace, false),
+            UseStacktrace = application:get_env(nova, use_stacktrace, false),
             persistent_term:put(nova_use_stacktrace, UseStacktrace),
             ?LOG_NOTICE(#{msg => <<"Nova is running">>,
                           url => unicode:characters_to_list(io_lib:format("http://~s:~B", [Host0, Port])),

--- a/src/nova_sup.erl
+++ b/src/nova_sup.erl
@@ -99,6 +99,8 @@ setup_cowboy(Configuration) ->
             Host0 = inet:ntoa(Host),
             CowboyVersion = get_version(cowboy),
             NovaVersion = get_version(nova),
+            UseStacktrace = application:get(nova, use_stacktrace, false),
+            persistent_term:put(nova_use_stacktrace, UseStacktrace),
             ?LOG_NOTICE(#{msg => <<"Nova is running">>,
                           url => unicode:characters_to_list(io_lib:format("http://~s:~B", [Host0, Port])),
                           cowboy_version => CowboyVersion, nova_version => NovaVersion, app => App});


### PR DESCRIPTION
Now we are storing a flag `nova_use_stacktrace` in `persistent_term`-storage and match accordingly. So iff the value is set to true we are getting the stack trace, otherwise not.