### PR TITLE
Move extra_state from Env to Req object

### DIFF
--- a/src/nova_router.erl
+++ b/src/nova_router.erl
@@ -66,13 +66,13 @@ execute(Req = #{host := Host, path := Path, method := Method}, Env) ->
                                            secure = Secure, plugins = Plugins, extra_state = ExtraState}} ->
             {ok,
              Req#{plugins => Plugins,
+                  extra_state => ExtraState,
                   bindings => Bindings},
              Env#{app => App,
                   module => Module,
                   function => Function,
                   secure => Secure,
-                  controller_data => #{},
-                  extra_state => ExtraState
+                  controller_data => #{}
                  }
             };
         {ok, Bindings, #cowboy_handler_value{app = App, handler = Handler, arguments = Args,


### PR DESCRIPTION
The `extra_state` object should be in the Req-object since that's the one accessible from both plugins and controllers.