### PR TITLE
Enhance plugins and security modules

### DIFF
--- a/src/nova_plugin_handler.erl
+++ b/src/nova_plugin_handler.erl
@@ -24,18 +24,44 @@ run_plugins([], Callback, Req, Env) ->
     {ok, Req, Env#{plugin_state => Callback}};
 run_plugins([{Module, Options}|Tl], Callback, Req, Env) ->
     ExtraState = maps:get(extra_state, Env, #{}),
-    try Module:Callback(Req#{extra_state => ExtraState}, Options) of
-        {ok, Req0} ->
-            run_plugins(Tl, Callback, Req0, Env);
-        {break, Req0} ->
-            {ok, Req0};
-        {stop, Req0} ->
-            {stop, Req0}
+    Req0 = Req#{extra_state => ExtraState},
+    Args = case proplists:get_value(Callback, Module:module_info(exports)) of
+               1 -> [Req0, Options];
+               2 -> [Req0, Env, Options];
+               _ -> {throw, bad_callback}
+           end,
+    try erlang:apply(Module, Callback, Args) of
+        {ok, Req1} ->
+            run_plugins(Tl, Callback, Req1, Env);
+        {ok, Reply, Req1} ->
+            Req2 = handle_reply(Reply, Req1),
+            run_plugins(Tl, Callback, Req2, Env);
+        {break, Req1} ->
+            {ok, Req1};
+        {break, Reply, Req1} ->
+            Req2 = handle_reply(Reply, Req1),
+            {ok, Req2};
+        {stop, Req1} ->
+            {stop, Req1};
+        {stop, Reply, Req1} ->
+            Req2 = handle_reply(Reply, Req1),
+            {stop, Req2}
     catch
         Class:Reason:Stacktrace ->
             ?LOG_ERROR(#{msg => <<"Plugin crashed">>, class => Class, reason => Reason, stacktrace => Stacktrace}),
-            Req0 = Req#{crash_info => #{class => Class,
-                                        reason => Reason,
-                                        stacktrace => Stacktrace}},
-            nova_router:render_status_page('_', 500, #{}, Req0, Env)
+            Req1 = Req0#{crash_info => #{class => Class,
+                                         reason => Reason,
+                                         stacktrace => Stacktrace}},
+            nova_router:render_status_page('_', 500, #{}, Req1, Env)
     end.
+
+handle_reply({reply, Body}, Req) ->
+    handle_reply({reply, 200, #{}, Body}, Req);
+handle_reply({reply, Status, Body}, Req) ->
+    handle_reply({reply, Status, #{}, Body}, Req);
+handle_reply({reply, Status, Headers, Body}, Req) ->
+    Req0 = cowboy_req:set_resp_headers(Headers, Req),
+    Req1 = cowboy_req:set_resp_body(Body, Req0),
+    Req1#{resp_status_code => Status};
+handle_reply(_, Req) ->
+    Req.

--- a/src/nova_security_handler.erl
+++ b/src/nova_security_handler.erl
@@ -12,30 +12,8 @@ execute(Req, Env = #{secure := false}) ->
 execute(Req = #{host := Host}, Env = #{secure := {Module, Function}}) ->
     UseStacktrace = persistent_term:get(nova_use_stacktrace, false),
     try Module:Function(Req) of
-        {true, AuthData} ->
-            case maps:get(cowboy_handler, Env, undefined) of
-                nova_ws_handler ->
-                    Args = maps:get(arguments, Env, #{}),
-                    {ok, Req, Env#{arguments => Args#{controller_data => #{auth_data => AuthData}}}};
-                _ ->
-                    {ok, Req#{auth_data => AuthData}, Env}
-            end;
-        true ->
-            {ok, Req, Env};
-        {false, Headers} ->
-            {ok, Req0, _Env0} = nova_router:render_status_page(Host, 401, #{}, Req, Env),
-            ExistingHeaders = cowboy_req:headers(Req),
-            FinalHeaders = maps:merge(ExistingHeaders, Headers),
-            Req1 = cowboy_req:set_resp_headers(FinalHeaders, Req0),
-            Req2 = cowboy_req:reply(401, Req1),
-            {stop, Req2};
-        {redirect, Route} ->
-            Req0 = cowboy_req:set_resp_headers(#{<<"Location">> => list_to_binary(Route)}, Req),
-            {stop, Req0};
-        _ ->
-            {ok, Req0, _Env0} = nova_router:render_status_page(Host, 401, #{}, Req, Env),
-            Req1 = cowboy_req:reply(401, Req0),
-            {stop, Req1}
+        Result ->
+            handle_response(Result, Req, Env)
     catch
         Class:Reason:Stacktrace when UseStacktrace == true ->
             ?LOG_ERROR(#{msg => <<"Security handler crashed">>,
@@ -60,3 +38,39 @@ execute(Req = #{host := Host}, Env = #{secure := {Module, Function}}) ->
             Req1 = cowboy_req:reply(500, Req0),
             {stop, Req1}
     end.
+
+
+
+handle_response({true, AuthData}, Req, Env) ->
+    case maps:get(cowboy_handler, Env, undefined) of
+        nova_ws_handler ->
+            Args = maps:get(arguments, Env, #{}),
+            {ok, Req, Env#{arguments => Args#{controller_data => #{auth_data => AuthData}}}};
+        _ ->
+            {ok, Req#{auth_data => AuthData}, Env}
+    end;
+handle_response(true, Req, Env) ->
+    {ok, Req, Env};
+handle_response({false, Headers}, Req, Env) ->
+    handle_response({false, 401, Headers, false}, Req, Env);
+handle_response({false, StatusCode, Headers}, Req, Env) ->
+    handle_response({false, StatusCode, Headers, false}, Req, Env);
+handle_response({false, StatusCode, Headers, Body}, Req = #{host := Host}, Env) ->
+    {ok, Req1, _Env1} =
+        case Body of
+            false ->
+                {ok, _Req0, _Env0} = nova_router:render_status_page(Host, StatusCode, #{}, Req, Env);
+            _ ->
+                Req0 = cowboy_req:set_resp_body(Body, Req),
+                {ok, Req0, Env}
+        end,
+    Req2 = cowboy_req:set_resp_headers(Headers, Req1),
+    Req3 = cowboy_req:reply(StatusCode, Req2),
+    {stop, Req3};
+handle_response({redirect, Route}, Req, _Env) ->
+    Req0 = cowboy_req:set_resp_headers(#{<<"Location">> => list_to_binary(Route)}, Req),
+    {stop, Req0};
+handle_response(_, Req = #{host := Host}, Env) ->
+    {ok, Req0, _Env0} = nova_router:render_status_page(Host, 401, #{}, Req, Env),
+    Req1 = cowboy_req:reply(401, Req0),
+    {stop, Req1}.


### PR DESCRIPTION
Before a plugin-function is called we check if it has arity 2 or 3. If it's 3 we include `Env` as the second argument.


This also introduce a mechanism to send replies to the caller by returning term of type `reply()` defined below.

```erlang
-type reply() :: {reply, Body :: iolist() | binary()} | 
                          {reply, Status :: integer(), Body :: iolist() | binary() |
                          {reply, Status :: integer(), Headers :: [{binary(), binary()}], Body :: iolist() | binary()
```


Also enriches the return object from a security-module.

Instead of returning `{false, Headers}` one can now return three different options:
```erlang
{false, Headers :: map()} |
{false, StatusCode :: integer(), Headers :: map()} |
{false, StatusCode :: integer(), Headers :: map(), Body :: iolist() | binary()}
```
