### PR TITLE
Fix read body for large payloads

### DIFF
--- a/src/plugins/nova_request_plugin.erl
+++ b/src/plugins/nova_request_plugin.erl
@@ -98,6 +98,6 @@ modulate_state(State, [_|Tl]) ->
 
 read_body(Req, Acc) ->
     case cowboy_req:read_body(Req) of
-        {ok, Data, Req0} -> Req0#{body => Data};
-        {more, Data, Req0} -> read_body(Req0, <<Data/binary, Acc/binary>>)
+        {ok, Data, Req0} -> Req0#{body => <<Acc/binary, Data/binary>>};
+        {more, Data, Req0} -> read_body(Req0, <<Acc/binary, Data/binary>>)
     end.


### PR DESCRIPTION
Fixes a bug caused by a payload (HTTP body) that is large enough that Cowboy streams it (i.e., when cowboy_req:read_body/2 is called multiple times). This is in line with the example given by Cowboy [here](https://ninenines.eu/docs/en/cowboy/2.10/manual/cowboy_req.read_body/)

Without this fix, only the last chunk of the stream is returned as the body of the request.