### PR TITLE
Added the view handler

### DIFF
--- a/src/nova_handlers.erl
+++ b/src/nova_handlers.erl
@@ -155,6 +155,7 @@ init([]) ->
     register_handler(redirect, fun nova_basic_handler:handle_redirect/3),
     register_handler(sendfile, fun nova_basic_handler:handle_sendfile/3),
     register_handler(ws, fun nova_basic_handler:handle_ws/2),
+    register_handler(view, fun nova_basic_handler:handle_view/3),
     {ok, #state{}}.
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
Added so we can handle the `{view, DTL}` from the controller. It was a missing handler that needed to be registered. Question is if we should add deprication on the `{ok, DTL}` part for view decleration.