### PR TITLE
[FEAT] Use funs instead of MF(A)

### DIFF
--- a/guides/deprecations.md
+++ b/guides/deprecations.md
@@ -1,0 +1,11 @@
+# Deprecations in Nova
+
+We try to keep the Nova API as stable as possible, but sometimes we need to depreciate old functionality.
+This is a list of the things that are currently deprecated in Nova.
+
+
+## 0.9.24
+
+- The old format with `{Module, Function}` is deprecated in favor of `fun Module:function/1`. This is a breaking change,
+but it is a good time to do it now before we release 1.0.0. The old format will be removed in 1.0.0. This goes for all occurrences
+of `{Module, Function}` in Nova.

--- a/guides/routing.md
+++ b/guides/routing.md
@@ -15,7 +15,7 @@ routes(_Environment) ->
   [#{prefix => "/admin",
     security => false,
     routes => [
-      {"/", {my_controller, main}, #{methods => [get]}}
+      {"/", fun my_controller:main/1, #{methods => [get]}}
     ]
   }].
 ```
@@ -29,7 +29,7 @@ The routing object consists of three or four fields.
 ### HTTP(S) Routing ###
 
 ```
-{Route :: list(), {Controller :: atom(), Function :: atom()}, Options :: map()}
+{Route :: list(), ControllerCallback :: function(), Options :: map()}
 ```
 
 As you saw in the initial example in the [Basic components](#basic-components) section, we defined a route for the root path `/`.
@@ -47,12 +47,11 @@ As you saw in the initial example in the [Basic components](#basic-components) s
 
 ## How to create routes
 
-A route consists of four different components:
+A route consists of three different components:
 
 * `Path` - This is the actual path to the endpoint. Eg `"/admin"`
 * `Method` - What method you want to support for this endpoint (get, post, update, delete). If you want to support all methods you can use the `'_'`-atom.
-* `Controller` - What erlang module should be called on when the path gets called.
-* `Function` - Which function in the `Controller` will be called when path gets called.
+* `ControllerCallback` - What erlang callback should be called on when the path gets called. This is defined as a function reference, eg `fun my_controller:main/1`.
 
 ## Using prefix
 
@@ -67,9 +66,9 @@ You can secure routes by providing a module and function to the `security` direc
 ```erlang
 #{prefix => "/admin",
   type => html,
-  security => {security_controller, do_security},
+  security => fun security_controller:do_security/1,
   routes => [
-    {"/", {my_controller, main}, #{methods => [get]}}
+    {"/", fun my_controller:main/1, #{methods => [get]}}
   ]
 }
 ```
@@ -98,7 +97,7 @@ It's possible to configure a small set of endpoints with a specific plugin. This
     {pre_request, nova_json_schemas, #{render_errors => true}}
   ],
   routes => [
-    {"/", {my_controller, main}, #{methods => [get]}}
+    {"/", fun my_controller:main/1, #{methods => [get]}}
   ]
 }
 ```
@@ -119,7 +118,7 @@ You can also add routes programatically by calling `nova_router:add_route/2`. Th
 First argument is the application you want to add the route to. The second argument is the route or a list of routes you want to add - it uses the same structure as in the regular routers.
 
 ```erlang
-nova_router:add_route(my_app, #{prefix => "/admin", routes => [{"/", {my_controller, main}, #{methods => [get]}}]}).
+nova_router:add_route(my_app, #{prefix => "/admin", routes => [{"/", fun my_controller:main/1, #{methods => [get]}}]}).
 ```
 
 This will add the routes defined in the second argument to the `my_app` application.

--- a/include/nova.hrl
+++ b/include/nova.hrl
@@ -1,0 +1,1 @@
+-define(LOG_DEPRECATED(SinceVersion, Msg), logger:warning("Deprecation warning. Since version: ~s, Message: ~s~nRead more about deprecations on https://github.com/novaframework/nova/blob/master/guides/deprecations.md", [SinceVersion, Msg])).

--- a/include/nova_router.hrl
+++ b/include/nova_router.hrl
@@ -3,6 +3,7 @@
                              app :: atom(),
                              module :: atom(),
                              function :: atom(),
+                             callback :: function() | undefined,
                              plugins = [] :: list(),
                              secure = false :: false | {Mod :: atom(), Fun :: atom()},
                              extra_state :: any()

--- a/src/nova_basic_handler.erl
+++ b/src/nova_basic_handler.erl
@@ -12,7 +12,6 @@
 
 -include_lib("kernel/include/logger.hrl").
 
--type mod_fun() :: {Module :: atom(), Function :: atom()} | undefined.
 -type erlydtl_vars() :: map() | [{Key :: atom() | binary() | string(), Value :: any()}].
 
 
@@ -31,22 +30,21 @@
 %% @end
 %%--------------------------------------------------------------------
 -spec handle_json({json, JSON :: map()} | {json, StatusCode :: integer(), Headers :: map(), JSON :: map()},
-                  ModFun :: mod_fun(), Req :: cowboy_req:req()) -> {ok, State :: cowboy_req:req()} |
-                                                                   {Module :: atom(), Req :: cowboy_req:req()}.
-handle_json({json, StatusCode, Headers, JSON}, _ModFun, Req) ->
+                  Callback :: function(), Req :: cowboy_req:req()) -> {ok, State :: cowboy_req:req()}.
+handle_json({json, StatusCode, Headers, JSON}, _Callback, Req) ->
     JsonLib = nova:get_env(json_lib, thoas),
-    EncodedJSON = erlang:apply(JsonLib, encode, [JSON]),
+    EncodedJSON = JsonLib:encode(JSON),
     Headers0 = maps:merge(#{<<"content-type">> => <<"application/json">>}, Headers),
     Req0 = cowboy_req:set_resp_headers(Headers0, Req),
     Req1 = cowboy_req:set_resp_body(EncodedJSON, Req0),
     Req2 = Req1#{resp_status_code => StatusCode},
     {ok, Req2};
-handle_json({json, JSON}, ModFun, Req = #{method := Method}) ->
+handle_json({json, JSON}, Callback, Req = #{method := Method}) ->
     case Method of
         <<"POST">> ->
-            handle_json({json, 201, #{}, JSON}, ModFun, Req);
+            handle_json({json, 201, #{}, JSON}, Callback, Req);
         _ ->
-            handle_json({json, 200, #{}, JSON}, ModFun, Req)
+            handle_json({json, 200, #{}, JSON}, Callback, Req)
     end.
 
 
@@ -75,16 +73,18 @@ handle_json({json, JSON}, ModFun, Req = #{method := Method}) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec handle_ok({ok, Variables :: erlydtl_vars()} | {ok, Variables :: erlydtl_vars(), Options :: map()},
-                ModFun :: mod_fun(), Req :: cowboy_req:req()) -> {ok, cowboy_req:req()}.
-handle_ok({ok, Variables}, {Mod, _Func}, Req) ->
+                Callback :: function(), Req :: cowboy_req:req()) -> {ok, cowboy_req:req()}.
+handle_ok({ok, Variables}, Callback, Req) ->
     %% Derive the view from module
-    ViewNameAtom = get_view_name(Mod),
+    {module, Module} = erlang:fun_info(Callback, module),
+    ViewNameAtom = get_view_name(Module),
     handle_view(ViewNameAtom, Variables, #{}, Req);
-handle_ok({ok, Variables, Options}, {Mod, _Func}, Req) ->
+handle_ok({ok, Variables, Options}, Callback, Req) ->
+    {module, Module} = erlang:fun_info(Callback, module),
     View =
         case maps:get(view, Options, undefined) of
             undefined ->
-                get_view_name(Mod);
+                get_view_name(Module);
             CustomView when is_atom(CustomView) ->
                 ViewName = atom_to_list(CustomView) ++ "_dtl",
                 list_to_atom(ViewName);
@@ -101,10 +101,10 @@ handle_ok({ok, Variables, Options}, {Mod, _Func}, Req) ->
 %% handle_ok/3.
 %% @end
 %%--------------------------------------------------------------------
-handle_view({view, Variables}, {Mod, Func}, Req) ->
-    handle_ok({ok, Variables}, {Mod, Func}, Req);
-handle_view({view, Variables, Options}, {Mod, Func}, Req) ->
-    handle_ok({ok, Variables, Options}, {Mod, Func}, Req).
+handle_view({view, Variables}, Callback, Req) ->
+    handle_ok({ok, Variables}, Callback, Req);
+handle_view({view, Variables, Options}, Callback, Req) ->
+    handle_ok({ok, Variables, Options}, Callback, Req).
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -123,29 +123,29 @@ handle_view({view, Variables, Options}, {Mod, Func}, Req) ->
 -spec handle_status({status, StatusCode :: integer()} |
                     {status, StatusCode :: integer(), ExtraHeaders :: map()} |
                     {status, StatusCode :: integer(), ExtraHeaders :: map(), Body :: binary() | map()},
-                    ModFun :: mod_fun(), Req :: cowboy_req:req()) -> {ok, Req :: cowboy_req:req()}.
-handle_status({status, Status, ExtraHeaders, JSON}, _ModFun, Req) when is_map(JSON) ->
+                    Callback :: function(), Req :: cowboy_req:req()) -> {ok, Req :: cowboy_req:req()}.
+handle_status({status, Status, ExtraHeaders, JSON}, _Callback, Req) when is_map(JSON) ->
     %% We do not need to render a status page since we just return a JSON structure
     JsonLib = nova:get_env(json_lib, thoas),
     Headers0 = maps:merge(#{<<"content-type">> => <<"application/json">>}, ExtraHeaders),
     Req0 = cowboy_req:set_resp_headers(Headers0, Req),
     Req1 = Req0#{resp_status_code => Status},
-    JSONStr = erlang:apply(JsonLib, encode, [JSON]),
+    JSONStr = JsonLib:encode(JSON),
     Req2 = cowboy_req:set_resp_body(JSONStr, Req1),
     {ok, Req2};
-handle_status({status, Status, ExtraHeaders, Body}, _ModFun, Req) ->
+handle_status({status, Status, ExtraHeaders, Body}, _Callback, Req) ->
     %% Body is a binary - just send it out
     Req0 = cowboy_req:set_resp_headers(ExtraHeaders, Req),
     Req1 = Req0#{resp_status_code => Status},
     Req2 = cowboy_req:set_resp_body(Body, Req1),
     {ok, Req2};
-handle_status({status, Status, ExtraHeaders}, _ModFun, Req) ->
+handle_status({status, Status, ExtraHeaders}, _Callback, Req) ->
     Req0 = cowboy_req:set_resp_headers(ExtraHeaders, Req),
     Req1 = Req0#{resp_status_code => Status},
     {ok, Req2, _Env} =  nova_router:render_status_page(Status, #{}, Req1),
     {ok, Req2};
-handle_status({status, Status}, ModFun, State) when is_integer(Status) ->
-    handle_status({status, Status, #{}}, ModFun, State).
+handle_status({status, Status}, Callback, State) when is_integer(Status) ->
+    handle_status({status, Status, #{}}, Callback, State).
 
 
 %%--------------------------------------------------------------------
@@ -155,11 +155,11 @@ handle_status({status, Status}, ModFun, State) when is_integer(Status) ->
 %% 302 with location set to "/login"
 %% @end
 %%-----------------------------------------------------------------
--spec handle_redirect({redirect, Route :: list()|binary()}, ModFun :: mod_fun(),
+-spec handle_redirect({redirect, Route :: list()|binary()}, Callback :: function(),
                       Req :: cowboy_req:req()) -> {ok, Req :: cowboy_req:req()}.
-handle_redirect({redirect, Route}, ModFun, Req) when is_list(Route) ->
-    handle_redirect({redirect, list_to_binary(Route)}, ModFun, Req);
-handle_redirect({redirect, Route}, _ModFun, Req) ->
+handle_redirect({redirect, Route}, Callback, Req) when is_list(Route) ->
+    handle_redirect({redirect, list_to_binary(Route)}, Callback, Req);
+handle_redirect({redirect, Route}, _Callback, Req) ->
     Headers = #{<<"Location">> => Route},
     Req0 = cowboy_req:set_resp_headers(Headers, Req),
     Req1 = Req0#{resp_status_code => 302},
@@ -173,8 +173,8 @@ handle_redirect({redirect, Route}, _ModFun, Req) ->
 -spec handle_sendfile({sendfile, StatusCode :: integer(), Headers :: map(), {Offset :: integer(),
                                                                              Length :: integer(),
                                                                              Path :: list()}, Mime :: binary()},
-                  ModFun :: mod_fun(), Req) -> {ok, Req} when Req :: cowboy_req:req().
-handle_sendfile({sendfile, StatusCode, Headers, {Offset, Length, Path}, Mime}, _ModFun, Req) ->
+                  Callback :: function(), Req) -> {ok, Req} when Req :: cowboy_req:req().
+handle_sendfile({sendfile, StatusCode, Headers, {Offset, Length, Path}, Mime}, _Callback, Req) ->
     Headers0 = maps:merge(#{<<"content-type">> => Mime}, Headers),
     Req0 = cowboy_req:set_resp_headers(Headers0, Req),
     Req1 = cowboy_req:set_resp_body({sendfile, Offset, Length, Path}, Req0),
@@ -187,9 +187,10 @@ handle_sendfile({sendfile, StatusCode, Headers, {Offset, Length, Path}, Mime}, _
 %% Handles upgrading to websocket
 %% @end
 %%-----------------------------------------------------------------
--spec handle_websocket({websocket, ControllerData :: any()}, ModFun :: mod_fun(), Req :: cowboy_req:req()) ->
+-spec handle_websocket({websocket, ControllerData :: any()}, Callback :: function(), Req :: cowboy_req:req()) ->
                               {ok, Req :: cowboy_req:req()}.
-handle_websocket({websocket, ControllerData}, {Module, _Fun}, Req) ->
+handle_websocket({websocket, ControllerData}, Callback, Req) ->
+    {module, Module} = erlang:fun_info(Callback, module),
     case Module:init(ControllerData) of
         {ok, NewControllerData} ->
             {cowboy_websocket, Req#{controller_data => NewControllerData}, #{}};

--- a/src/nova_handler.erl
+++ b/src/nova_handler.erl
@@ -21,14 +21,14 @@
                                when Req::cowboy_req:req(), Env::cowboy_middleware:env().
 execute(Req, Env = #{cowboy_handler := Handler, arguments := Arguments}) ->
     UseStacktrace = persistent_term:get(nova_use_stacktrace, false),
-    try erlang:apply(Handler, init, [Req, Arguments]) of
+    try Handler:init(Req, Arguments) of
         {ok, Req2, _State} ->
-            Result = terminate(normal, Req2, Handler),
+            Result = terminate(normal, Req2, fun Handler:dummy/1),
             {ok, Req2, Env#{result => Result}};
         {Mod, Req2, State} ->
-            erlang:apply(Mod, upgrade, [Req2, Env, Handler, State]);
+            Mod:upgrade(Req2, Env, Handler, State);
         {Mod, Req2, State, Opts} ->
-            erlang:apply(Mod, upgrade, [Req2, Env, Handler, State, Opts])
+            Mod:upgrade(Req2, Env, Handler, State, Opts)
     catch
         Class:Reason:Stacktrace when UseStacktrace == true ->
             Payload = #{status_code => 404,
@@ -44,11 +44,11 @@ execute(Req, Env = #{cowboy_handler := Handler, arguments := Arguments}) ->
             ?LOG_ERROR(#{msg => <<"Controller crashed">>, class => Class, reason => Reason}),
             render_response(Req#{crash_info => Payload}, maps:remove(cowboy_handler, Env), 404)
     end;
-execute(Req, Env = #{module := Module, function := Function}) ->
+execute(Req, Env = #{callback := Callback}) ->
     %% Ensure that the module exists and have the correct function exported
     UseStacktrace = persistent_term:get(nova_use_stacktrace, false),
-    try RetObj = erlang:apply(Module, Function, [Req]),
-         call_handler(Module, Function, Req, RetObj, Env, false)
+    try RetObj = Callback(Req),
+         call_handler(Callback, Req, RetObj, Env, false)
     of
         HandlerReturn ->
             HandlerReturn
@@ -64,7 +64,7 @@ execute(Req, Env = #{module := Module, function := Function}) ->
                          class => Class,
                          reason => Reason,
                          stacktrace => Stacktrace}),
-            terminate(Reason, Req, Module),
+            terminate(Reason, Req, Callback),
             %% Build the payload object
             Payload = #{status_code => 500,
                         stacktrace => Stacktrace,
@@ -75,7 +75,7 @@ execute(Req, Env = #{module := Module, function := Function}) ->
             ?LOG_ERROR(#{msg => <<"Controller crashed">>,
                          class => Class,
                          reason => Reason}),
-            terminate(Reason, Req, Module),
+            terminate(Reason, Req, Callback),
             %% Build the payload object
             Payload = #{status_code => 500,
                         class => Class,
@@ -83,11 +83,12 @@ execute(Req, Env = #{module := Module, function := Function}) ->
             render_response(Req#{crash_info => Payload}, Env, 500)
     end.
 
--spec terminate(any(), Req | undefined, module()) -> ok when Req::cowboy_req:req().
-terminate(Reason, Req, Module) ->
+-spec terminate(any(), Req :: cowboy_req:req() | undefined, function()) -> ok.
+terminate(Reason, Req, Callback) ->
+    {module, Module} = erlang:fun_info(Callback, module),
     case function_exported(Module, terminate, 3) of
         true ->
-            erlang:apply(Module, terminate, [Reason, Req]);
+            Module:terminate(Reason, Req);
         false ->
             ok
     end.
@@ -96,10 +97,11 @@ terminate(Reason, Req, Module) ->
 %%%%%%%%%%%%%%%%%%%%%%%%
 %% INTERNAL FUNCTIONS %%
 %%%%%%%%%%%%%%%%%%%%%%%%
--spec execute_fallback(Module :: atom(), Req :: cowboy_req:req(), Response :: any(), Env :: map()) ->
+-spec execute_fallback(Callback :: function(), Req :: cowboy_req:req(), Response :: any(), Env :: map()) ->
           {ok, Req0 :: cowboy_req:req(), Env :: map()}.
-execute_fallback(Module, Req, Response, Env) ->
-    Attributes = erlang:apply(Module, module_info, [attributes]),
+execute_fallback(Callback, Req, Response, Env) ->
+    {module, Module} = erlang:fun_info(Callback, module),
+    Attributes = Module:module_info(attributes),
     case proplists:get_value(fallback_controller, Attributes, undefined) of
         undefined ->
             %% No fallback - render a crash-page
@@ -113,8 +115,8 @@ execute_fallback(Module, Req, Response, Env) ->
         [FallbackModule] ->
             case function_exported(FallbackModule, resolve, 2) of
                 true ->
-                    RetObj = erlang:apply(FallbackModule, resolve, [Req, Response]),
-                    call_handler(FallbackModule, resolve, Req, RetObj, Env, true);
+                    RetObj = FallbackModule:resolve(Req, Response),
+                    call_handler(fun FallbackModule:resolve/1, Req, RetObj, Env, true);
                 _ ->
                     Payload = #{status_code => 500,
                                 status => <<"Problems with fallback-controller">>,
@@ -126,17 +128,19 @@ execute_fallback(Module, Req, Response, Env) ->
             end
     end.
 
--spec call_handler(Module :: atom(), Function :: atom(), Req :: cowboy_req:req(),
+-spec call_handler(Callback :: function(), Req :: cowboy_req:req(),
                    RetObj :: any(), Env :: map(), IsFallbackController :: boolean()) ->
           {ok, Req0 :: cowboy_req:req(), Env :: map()}.
-call_handler(Module, Function, Req, RetObj, Env, IsFallbackController) ->
+call_handler(Callback, Req, RetObj, Env, IsFallbackController) ->
     case nova_handlers:get_handler(element(1, RetObj)) of
-        {ok, Callback} ->
-            {ok, Req0} = Callback(RetObj, {Module, Function}, Req),
+        {ok, HandlerCallback} ->
+            {ok, Req0} = HandlerCallback(RetObj, Callback, Req),
             render_response(Req0, Env);
         {error, not_found} ->
             case IsFallbackController of
                 true ->
+                    {module, Module} = erlang:fun_info(Callback, module),
+                    {name, Function} = erlang:fun_info(Callback, name),
                     ?LOG_ERROR(#{msg => <<"Controller returned unsupported result">>, controller => Module,
                                  function => Function, return => RetObj}),
                     Payload = #{status_code => 500,
@@ -147,7 +151,7 @@ call_handler(Module, Function, Req, RetObj, Env, IsFallbackController) ->
                                                                           [Module, Function, RetObj]))},
                     render_response(Req#{crash_info => Payload}, Env, 500);
                 _ ->
-                    execute_fallback(Module, Req, RetObj, Env)
+                    execute_fallback(Callback, Req, RetObj, Env)
             end
     end.
 
@@ -166,20 +170,20 @@ render_response(Req, Env, StatusCode) ->
             case nova_router:lookup_url(StatusCode) of
                 {error, _} ->
                     %% Render the internal view of nova
-                    {ok, Req0} = nova_basic_handler:handle_status({status, StatusCode}, {dummy, dummy}, Req),
+                    {ok, Req0} = nova_basic_handler:handle_status({status, StatusCode}, fun erlang:date/0, Req),
                     render_response(Req0, Env);
-                {ok, _Bindings, #nova_handler_value{module = EMod, function = EFunc}} ->
+                {ok, _Bindings, #nova_handler_value{callback = Callback}} ->
                     %% Recurse to the execute function to render error page
-                    execute(Req, Env#{app => nova, module => EMod, function => EFunc})
+                    execute(Req, Env#{app => nova, callback => Callback})
             end;
         false ->
-            {ok, Req0} = nova_basic_handler:handle_status({status, StatusCode}, {dummy, dummy}, Req),
+            {ok, Req0} = nova_basic_handler:handle_status({status, StatusCode}, fun(_) -> ok end, Req),
             render_response(Req0, Env)
     end.
 
 
 function_exported(Module, Function, Arity) ->
-    Exports = erlang:apply(Module, module_info, [exports]),
+    Exports = Module:module_info(exports),
     case proplists:get_value(Function, Exports) of
         A when A == Arity ->
             true;

--- a/src/nova_router.erl
+++ b/src/nova_router.erl
@@ -319,7 +319,8 @@ parse_url(Host, [{Path, {Mod, Func}, Options}|Tl], Prefix,
 parse_url(Host, [{Path, Callback}|Tl], Prefix, Value, Tree) when is_function(Callback) ->
     %% Recurse with same args but with added options
     parse_url(Host, [{Path, Callback, #{}}|Tl], Prefix, Value, Tree);
-parse_url(Host, [{Path, Callback, Options}|Tl], Prefix, Value = #nova_handler_value{app = App}, Tree) when is_function(Callback) ->
+parse_url(Host, [{Path, Callback, Options}|Tl], Prefix, Value = #nova_handler_value{app = App}, Tree)
+  when is_function(Callback) ->
     case maps:get(protocol, Options, http) of
         http ->
             %% Transform the path to a string format

--- a/src/nova_router.erl
+++ b/src/nova_router.erl
@@ -33,6 +33,7 @@
 -include_lib("routing_tree/include/routing_tree.hrl").
 -include_lib("kernel/include/logger.hrl").
 -include("../include/nova_router.hrl").
+-include("../include/nova.hrl").
 
 -type bindings() :: #{binary() := binary()}.
 -export_type([bindings/0]).
@@ -65,15 +66,14 @@ execute(Req = #{host := Host, path := Path, method := Method}, Env) ->
     case routing_tree:lookup(Host, Path, Method, Dispatch) of
         {error, not_found} -> render_status_page('_', 404, #{error => "Not found in path"}, Req, Env);
         {error, comparator_not_found} -> render_status_page('_', 405, #{error => "Method not allowed"}, Req, Env);
-        {ok, Bindings, #nova_handler_value{app = App, module = Module, function = Function,
-                                           secure = Secure, plugins = Plugins, extra_state = ExtraState}} ->
+        {ok, Bindings, #nova_handler_value{app = App, callback = Callback, secure = Secure, plugins = Plugins,
+                                           extra_state = ExtraState}} ->
             {ok,
              Req#{plugins => Plugins,
                   extra_state => ExtraState,
                   bindings => Bindings},
              Env#{app => App,
-                  module => Module,
-                  function => Function,
+                  callback => Callback,
                   secure => Secure,
                   controller_data => #{}
                  }
@@ -154,7 +154,8 @@ add_routes(App, [Routes|Tl]) when is_list(Routes) ->
 
     add_routes(App, Tl);
 add_routes(App, Routes) ->
-    add_routes(App, [Routes]).
+    ?LOG_ERROR(#{reason => <<"Invalid routes structure">>, app => App, routes => Routes}),
+    throw({error, {invalid_routes, App, Routes}}).
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%
@@ -169,8 +170,8 @@ compile([App|Tl], Dispatch, Options) ->
     %% Fetch the router-module for this application
     Router = erlang:list_to_atom(io_lib:format("~s_router", [App])),
     Env = nova:get_environment(),
-    %% Ensure that the module is loaded
-    Routes = erlang:apply(Router, routes, [Env]),
+    %% Call the router
+    Routes = Router:routes(Env),
     Options1 = Options#{app => App},
 
     {ok, Dispatch1, Options2} = compile_paths(Routes, Dispatch, Options1),
@@ -191,11 +192,21 @@ compile_paths([RouteInfo|Tl], Dispatch, Options) ->
     GlobalPlugins = application:get_env(nova, plugins, []),
     Plugins = maps:get(plugins, RouteInfo, GlobalPlugins),
 
-    Value = #nova_handler_value{secure = maps:get(secure, Options, maps:get(security, RouteInfo, false)),
-                                app = App, plugins = normalize_plugins(Plugins),
+    Secure =
+        case maps:get(secure, Options, maps:get(security, RouteInfo, false)) of
+            false ->
+                false;
+            {SMod, SFun} ->
+                ?LOG_DEPRECATED("v0.9.24", "The {Mod,Fun} format have been deprecated. Use the new format for routes."),
+                fun SMod:SFun/1;
+            SCallback ->
+                SCallback
+        end,
+
+    Value = #nova_handler_value{secure = Secure, app = App, plugins = normalize_plugins(Plugins),
                                 extra_state = maps:get(extra_state, RouteInfo, #{})},
 
-    Prefix = maps:get(prefix, Options, "") ++ maps:get(prefix, RouteInfo, ""),
+    Prefix = concat_strings(maps:get(prefix, Options, ""), maps:get(prefix, RouteInfo, "")),
     Host = maps:get(host, RouteInfo, '_'),
     SubApps = maps:get(apps, RouteInfo, []),
     %% We need to add this app info to nova-env
@@ -210,20 +221,9 @@ compile_paths([RouteInfo|Tl], Dispatch, Options) ->
     compile_paths(Tl, Dispatch2, Options).
 
 parse_url(_Host, [], _Prefix, _Value, Tree) -> {ok, Tree};
-parse_url(Host, [{StatusCode, StaticFile}|Tl], Prefix, Value, Tree) when is_integer(StatusCode),
-                                                                         is_list(StaticFile) ->
-    %% We need to signal that we have a static file here somewhere
-    Value0 = Value#nova_handler_value{
-               module = nova_static,
-               function = execute},
-
-    %% TODO! Fix status-code so it's being threated specially
-    Tree0 = insert(Host, StatusCode, '_', Value0, Tree),
-    parse_url(Host, Tl, Prefix, Value0, Tree0);
-parse_url(Host, [{StatusCode, {Module, Function}, Options}|Tl], Prefix, Value, Tree) when is_integer(StatusCode) ->
-    Value0 = Value#nova_handler_value{
-               module = Module,
-               function = Function},
+parse_url(Host, [{StatusCode, Callback, Options}|Tl], Prefix, Value, Tree) when is_integer(StatusCode) andalso
+                                                                                is_function(Callback) ->
+    Value0 = Value#nova_handler_value{callback = Callback},
     Res = lists:foldl(fun(Method, Tree0) ->
                               insert(Host, StatusCode, Method, Value0, Tree0)
                       end, Tree, maps:get(methods, Options, ['_'])),
@@ -309,45 +309,46 @@ parse_url(Host,
     Tree0 = insert(Host, string:concat(Prefix, RemotePath), '_', Value0, Tree),
     parse_url(Host, Tl, Prefix, Value, Tree0);
 
+parse_url(Host, [{Path, {Mod, Func}}|Tl], Prefix, Value, Tree) ->
+    %% Recurse with same args but with added options
+    parse_url(Host, [{Path, {Mod, Func}, #{}}|Tl], Prefix, Value, Tree);
 parse_url(Host, [{Path, {Mod, Func}, Options}|Tl], Prefix,
-          Value = #nova_handler_value{app = App, secure = _Secure}, Tree) ->
+          Value = #nova_handler_value{app = _App, secure = _Secure}, Tree) ->
+    ?LOG_DEPRECATED(<<"v0.9.24">>, <<"The {Mod,Fun} format have been deprecated. Use the new format for routes.">>),
+    parse_url(Host, [{Path, fun Mod:Func/1, Options}|Tl], Prefix, Value, Tree);
+parse_url(Host, [{Path, Callback}|Tl], Prefix, Value, Tree) when is_function(Callback) ->
+    %% Recurse with same args but with added options
+    parse_url(Host, [{Path, Callback, #{}}|Tl], Prefix, Value, Tree);
+parse_url(Host, [{Path, Callback, Options}|Tl], Prefix, Value = #nova_handler_value{app = App}, Tree) when is_function(Callback) ->
+    case maps:get(protocol, Options, http) of
+        http ->
+            %% Transform the path to a string format
+            RealPath = concat_strings(Prefix, Path),
 
-    RealPath = case Path of
-                   _ when is_list(Path) -> string:concat(Prefix, Path);
-                   _ when is_binary(Path) -> string:concat(Prefix, binary_to_list(Path));
-                   _ when is_integer(Path) -> Path;
-                   _ -> throw({unknown_path, Path})
-               end,
-    Methods = maps:get(methods, Options, ['_']),
+            Methods = maps:get(methods, Options, ['_']),
 
+            ExtraState = maps:get(extra_state, Options, undefined),
+            Value0 = Value#nova_handler_value{extra_state = ExtraState},
 
-    Value0 = case maps:get(extra_state, Options, undefined) of
-                 undefined ->
-                     Value;
-                 ExtraState ->
-                     Value#nova_handler_value{extra_state = ExtraState}
-             end,
-
-    CompiledPaths =
-        lists:foldl(
-          fun(Method, Tree0) ->
-                  BinMethod = method_to_binary(Method),
-                  Value1 =
-                      case maps:get(protocol, Options, http) of
-                          http ->
-                              Value0#nova_handler_value{
-                                module = Mod,
-                                function = Func
-                               }
-                      end,
-                  ?LOG_DEBUG(#{action => <<"Adding route">>, route => RealPath, app => App, method => Method}),
-                  insert(Host, RealPath, BinMethod, Value1, Tree0)
-          end, Tree, Methods),
-    parse_url(Host, Tl, Prefix, Value, CompiledPaths);
+            CompiledPaths =
+                lists:foldl(
+                  fun(Method, Tree0) ->
+                          BinMethod = method_to_binary(Method),
+                          Value1 = Value0#nova_handler_value{
+                                     callback = Callback
+                                    },
+                          ?LOG_DEBUG(#{action => <<"Adding route">>, route => RealPath, app => App, method => Method}),
+                          insert(Host, RealPath, BinMethod, Value1, Tree0)
+                  end, Tree, Methods),
+            parse_url(Host, Tl, Prefix, Value, CompiledPaths);
+        OtherProtocol ->
+            ?LOG_ERROR(#{reason => <<"Unknown protocol">>, protocol => OtherProtocol}),
+            parse_url(Host, Tl, Prefix, Value, Tree)
+    end;
 parse_url(Host,
           [{Path, Mod, #{protocol := ws}} | Tl],
           Prefix, #nova_handler_value{app = App, secure = Secure} = Value,
-          Tree) ->
+          Tree) when is_atom(Mod) ->
      Value0 =  #cowboy_handler_value{
                   app = App,
                   handler = nova_ws_handler,
@@ -356,11 +357,10 @@ parse_url(Host,
                   secure = Secure},
 
     ?LOG_DEBUG(#{action => <<"Adding route">>, protocol => <<"ws">>, route => Path, app => App}),
-    RealPath = string:concat(Prefix, Path),
+    RealPath = concat_strings(Prefix, Path),
     CompiledPaths = insert(Host, RealPath, '_', Value0, Tree),
-    parse_url(Host, Tl, Prefix, Value, CompiledPaths);
-parse_url(Host, [{Path, {Mod, Func}}|Tl], Prefix, Value, Tree) ->
-    parse_url(Host, [{Path, {Mod, Func}, #{}}|Tl], Prefix, Value, Tree).
+    parse_url(Host, Tl, Prefix, Value, CompiledPaths).
+
 
 -spec render_status_page(StatusCode :: integer(), Req :: cowboy_req:req()) ->
                                 {ok, Req0 :: cowboy_req:req(), Env :: map()}.
@@ -387,25 +387,21 @@ render_status_page(Host, StatusCode, Data, Req, Env) ->
             {error, _} ->
                 %% Render nova page if exists - We need to determine where to find this path?
                 {Req, Env#{app => nova,
-                           module => nova_error_controller,
-                           function => status_code,
+                           callback => fun nova_error_controller:status_code/1,
                            secure => false,
                            controller_data => #{status => StatusCode, data => Data}}};
             {ok, Bindings, #nova_handler_value{app = App,
-                                               module = Module,
-                                               function = Function,
+                                               callback = Callback,
                                                secure = Secure,
                                                extra_state = ExtraState}} ->
                 {
                  Req#{extra_state => ExtraState, bindings => Bindings, resp_status_code => StatusCode},
                  Env#{app => App,
-                      module => Module,
-                      function => Function,
+                      callback => Callback,
                       secure => Secure,
                       controller_data => #{status => StatusCode, data => Data},
                       bindings => Bindings}
                 }
-
         end,
     {ok, Req0, Env0}.
 
@@ -445,6 +441,16 @@ method_to_binary(patch) -> <<"PATCH">>;
 method_to_binary(Method) ->
     ?LOG_WARNING(#{reason => <<"Unknown method - defaulting to '_'">>, given_method => Method}),
     '_'.
+
+
+concat_strings(Path1, Path2) when is_binary(Path1) ->
+    concat_strings(binary_to_list(Path1), Path2);
+concat_strings(Path1, Path2) when is_binary(Path2) ->
+    concat_strings(Path1, binary_to_list(Path2));
+concat_strings(_Path1, Path2) when is_integer(Path2) ->
+    Path2;
+concat_strings(Path1, Path2) when is_list(Path1), is_list(Path2) ->
+    string:concat(Path1, Path2).
 
 -spec routes(Env :: atom()) -> [map()].
 routes(_) ->

--- a/src/nova_security_handler.erl
+++ b/src/nova_security_handler.erl
@@ -6,12 +6,13 @@
         ]).
 
 -include_lib("kernel/include/logger.hrl").
+-include("../include/nova.hrl").
 
 execute(Req, Env = #{secure := false}) ->
     {ok, Req, Env};
-execute(Req = #{host := Host}, Env = #{secure := {Module, Function}}) ->
+execute(Req = #{host := Host}, Env = #{secure := Callback}) ->
     UseStacktrace = persistent_term:get(nova_use_stacktrace, false),
-    try Module:Function(Req) of
+    try Callback(Req) of
         Result ->
             handle_response(Result, Req, Env)
     catch


### PR DESCRIPTION
This changes the behavior in Nova in regards to referencing routes and modules;

For http-routes we are using the `{Module, Func}` notation today but with this commit it will change into `fun Module:Func/1` which might be a bit clearer. This is also applicable when defining a security-handler.

