### PR TITLE
Fix a potential problem with correlation-id header

### DIFF
--- a/src/plugins/nova_correlation_plugin.erl
+++ b/src/plugins/nova_correlation_plugin.erl
@@ -73,7 +73,7 @@ plugin_info() ->
     }.
 
 get_correlation_id(Req, #{ request_correlation_header := CorrelationHeader }) ->
-    CorrelationHeaderLower = jhn_stdlib:to_lower(CorrelationHeader),
+    CorrelationHeaderLower = jhn_bstring:to_lower(CorrelationHeader),
     case cowboy_req:header(CorrelationHeaderLower, Req) of
         undefined ->
             uuid();

--- a/src/plugins/nova_correlation_plugin.erl
+++ b/src/plugins/nova_correlation_plugin.erl
@@ -56,7 +56,7 @@ pre_request(Req0, Opts) ->
     CorrId = get_correlation_id(Req0, Opts),
     %% Update the loggers metadata with correlation-id
     ok = update_logger_metadata(CorrId, Opts),
-    Req1 = cowboy_req:set_resp_header(<<"X-Correlation-ID">>, CorrId, Req0),
+    Req1 = cowboy_req:set_resp_header(<<"x-correlation-id">>, CorrId, Req0),
     Req = Req1#{correlation_id => CorrId},
     {ok, Req}.
 
@@ -73,7 +73,8 @@ plugin_info() ->
     }.
 
 get_correlation_id(Req, #{ request_correlation_header := CorrelationHeader }) ->
-    case cowboy_req:header(CorrelationHeader, Req) of
+    CorrelationHeaderLower = jhn_stdlib:to_lower(CorrelationHeader),
+    case cowboy_req:header(CorrelationHeaderLower, Req) of
         undefined ->
             uuid();
         CorrId ->


### PR DESCRIPTION
The documentation should state that the config value should be in lowercase when using the `request_correlation_header` option for the `nova_correlation_plugin`. This commit does not add that to the docs but rather transforms the value to lowercase instead. This should be a bit more in line with Novas philosophy about making it simple for developers . 

resolves #295 