### PR TITLE
WIP: Dynamically add applications to Nova

### DIFF
--- a/src/nova_router.erl
+++ b/src/nova_router.erl
@@ -52,8 +52,13 @@ compiled_apps() ->
 -spec compile(Apps :: [atom() | {atom(), map()}]) -> host_tree().
 compile(Apps) ->
     UseStrict = application:get_env(nova, use_strict_routing, false),
-    Dispatch = compile(Apps, routing_tree:new(#{use_strict => UseStrict, convert_to_binary => true}), #{}),
     StorageBackend = application:get_env(nova, dispatch_backend, persistent_term),
+
+    StoredDispatch = StorageBackend:get(nova_dispatch,
+                                        routing_tree:new(#{use_strict => UseStrict,
+                                                           convert_to_binary => true})),
+    Dispatch = compile(Apps, StoredDispatch, #{}),
+    %% Write the updated dispatch to storage
     StorageBackend:put(nova_dispatch, Dispatch),
     Dispatch.
 

--- a/src/nova_sup.erl
+++ b/src/nova_sup.erl
@@ -8,7 +8,10 @@
 -behaviour(supervisor).
 
 %% API
--export([start_link/0]).
+-export([
+         start_link/0,
+         add_application/2
+        ]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -33,6 +36,20 @@
 start_link() ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
+%%--------------------------------------------------------------------
+%% @doc
+%% Add a Nova application. This can either be on the same cowboy server that
+%% a previous application was started with, or a new one if the configuration
+%% ie port is different.
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec add_application(App :: atom(), Configuration :: map()) -> {ok, App :: atom(),
+                                                                 Host :: inet:ip_address(), Port :: number()}
+              | {error, Reason :: any()}.
+add_application(App, Configuration) ->
+    setup_cowboy(App, Configuration).
+
 %%%===================================================================
 %%% Supervisor callbacks
 %%%===================================================================
@@ -53,13 +70,11 @@ init([]) ->
                  intensity => 1,
                  period => 5},
 
+    %% Bootstrap the environment
     Environment = nova:get_environment(),
-
     nova_pubsub:start(),
 
     ?LOG_NOTICE(#{msg => <<"Starting nova">>, environment => Environment}),
-
-    Configuration = application:get_env(nova, cowboy_configuration, #{}),
 
     SessionManager = application:get_env(nova, session_manager, nova_session_ets),
 
@@ -69,7 +84,7 @@ init([]) ->
                 child(nova_watcher, nova_watcher)
                ],
 
-    setup_cowboy(Configuration),
+    setup_cowboy(),
 
 
     {ok, {SupFlags, Children}}.
@@ -94,8 +109,17 @@ child(Id, Type, Mod) ->
 child(Id, Mod) ->
     child(Id, worker, Mod).
 
-setup_cowboy(Configuration) ->
-    case start_cowboy(Configuration) of
+
+%%%-------------------------------------------------------------------
+%%% Nova Cowboy setup
+%%%-------------------------------------------------------------------
+setup_cowboy() ->
+    CowboyConfiguration = application:get_env(nova, cowboy_configuration, #{}),
+    BootstrapApp = application:get_env(nova, bootstrap_application, undefined),
+    setup_cowboy(BootstrapApp, CowboyConfiguration).
+
+setup_cowboy(BootstrapApp, Configuration) ->
+    case start_cowboy(BootstrapApp, Configuration) of
         {ok, App, Host, Port} ->
             Host0 = inet:ntoa(Host),
             CowboyVersion = get_version(cowboy),
@@ -109,10 +133,13 @@ setup_cowboy(Configuration) ->
             ?LOG_ERROR(#{msg => <<"Cowboy could not start">>, reason => Error})
     end.
 
+
 -spec start_cowboy(Configuration :: map()) ->
           {ok, BootstrapApp :: atom(), Host :: string() | {integer(), integer(), integer(), integer()},
            Port :: integer()} | {error, Reason :: any()}.
-start_cowboy(Configuration) ->
+start_cowboy(BootstrapApp, Configuration) ->
+
+    %% Cowboy configuration
     Middlewares = [
                    nova_router, %% Lookup routes
                    nova_plugin_handler, %% Handle pre-request plugins
@@ -123,6 +150,10 @@ start_cowboy(Configuration) ->
     StreamH = [nova_stream_h,
                cowboy_compress_h,
                cowboy_stream_h],
+
+    %% Good debug message in case someone wants to double check which config they are running with
+    logger:debug(#{msg => <<"Configure cowboy">>, stream_handlers => StreamH, middlewares => Middlewares}),
+
     StreamHandlers = maps:get(stream_handlers, Configuration, StreamH),
     MiddlewareHandlers = maps:get(middleware_handlers, Configuration, Middlewares),
     Options = maps:get(options, Configuration, #{compress => true}),
@@ -130,8 +161,6 @@ start_cowboy(Configuration) ->
     %% Build the options map
     CowboyOptions1 = Options#{middlewares => MiddlewareHandlers,
                               stream_handlers => StreamHandlers},
-
-    BootstrapApp = application:get_env(nova, bootstrap_application, undefined),
 
     %% Compile the routes
     Dispatch =


### PR DESCRIPTION
This allows a user to add/remove/update a Nova application during runtime.

Work left:
[ ] Check if a cowboy server already runs with given configuration
[ ] Add "Remove application"-logic
[ ] Write documentation
[ ] Test this properly so we don't break anything
[ ] Make the update route-strategy configurable (overwrite existing, ignore if exists etc)
