### PR TITLE
Add default values to nova configuration-section and update ssl-default

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -14,7 +14,7 @@ Nova uses Cowboy as the webserver. Cowboy is a very flexible webserver and Nova 
 | `ip` | IP to bind to | `tuple` | `{0, 0, 0, 0}` |
 | `port` | Port to bind to | `integer()` | `8080` |
 | `use_ssl` | If SSL should be used | `boolean()` | `false` |
-| `ssl_options` | Transport options for SSL. Nova uses ranch_ssl module so read about available options on [their page](https://ninenines.eu/docs/en/ranch/2.0/manual/ranch_ssl/). | `ranch_ssl:opts()` | `#{cert => "/path/to/cert.pem", key => "/path/to/key.pem"}` |
+| `ssl_options` | Transport options for SSL. Nova uses ranch_ssl module so read about available options on [their page](https://ninenines.eu/docs/en/ranch/2.0/manual/ranch_ssl/). | `ranch_ssl:opts()` | `#{cert => "/path/to/fullchain.pem", key => "/path/to/privkey.pem"}` |
 | `ssl_port` | Port to bind to when using SSL | `integer()` | `8443` |
 | `ca_cert` | Path to CA-cert *Deprecated since 0.10.3 - Read with `ssl_options`*| `string()` | `undefined` |
 | `cert` | Path to cert *Deprecated since 0.10.3 - Replaced with `ssl_options`*| `string()` | `undefined` |
@@ -24,16 +24,16 @@ Nova uses Cowboy as the webserver. Cowboy is a very flexible webserver and Nova 
 
 Following parameters should be defined under the `nova`-key in your *sys.config*.
 
-| Key | Description | Value |
-|-----|-------------|-------|
-| `use_persistent_term` | Use `persistent_term` module to store routing tree | `boolean()` |
-| `use_stacktrace` | If Nova should include stacktrace in error-pages | `boolean()` |
-| `render_error_pages` | If Nova should render error-pages for HTML-request | `boolean()` |
-| `use_sessions` | Turn off/on support for sessions | `boolean()` |
-| `session_manager` | Specifify a module to use as the session manager. Defaults to `nova_session_ets` | `atom()` |
-| `use_strict_routing`    | If the routing module should work under the strict mode. Using strict mode will cause errors if non-deterministic paths are detected. This is a beta-function so use with caution. | `boolean()` |
-| `bootstrap_application` | Define which application to bootstrap with Nova. This should be the name of your application. | `atom()` |
-| `cowboy_configuration` | If you need some additional configuration done to Cowboy this is the place. Check `nova_sup` module to learn which keys that can be defined. | `map()` |
+| Key | Description | Value | Default |
+|-----|-------------|-------|---------|
+| `use_persistent_term` | Use `persistent_term` module to store routing tree | `boolean()` | `true` |
+| `use_stacktrace` | If Nova should include stacktrace in error-pages | `boolean()` | `false` |
+| `render_error_pages` | If Nova should render error-pages for HTML-request | `boolean()` | `true` |
+| `use_sessions` | Turn off/on support for sessions | `boolean()` | `true` |
+| `session_manager` | Specifify a module to use as the session manager. Defaults to `nova_session_ets` | `atom()` | `nova_session_ets` |
+| `use_strict_routing`    | If the routing module should work under the strict mode. Using strict mode will cause errors if non-deterministic paths are detected. This is a beta-function so use with caution. | `boolean()` | `false` |
+| `bootstrap_application` | Define which application to bootstrap with Nova. This should be the name of your application. | `atom()` | *Will crash if not defined* |
+| `cowboy_configuration` | If you need some additional configuration done to Cowboy this is the place. Check `nova_sup` module to learn which keys that can be defined. | `map()` | `#{}` |
 
 ## Application parameters
 


### PR DESCRIPTION
This adds the default values to the configuration-documentation and also clarifies the SSL-example shown in the same document to better reflect if one is using lets encrypt. Closes #304 