### PR TITLE
fix: deal with stack traces with absent file or line number

### DIFF
--- a/src/controllers/nova_error_controller.erl
+++ b/src/controllers/nova_error_controller.erl
@@ -90,13 +90,23 @@ format_stacktrace(not_enabled) ->
     logger:warning("Stacktrace disabled. If you want to enable stacktraces call nova:stracktrace(true) or update your sys.config - Read more in the docs"),
     [];
 format_stacktrace([]) -> [];
-format_stacktrace([{Mod, Func, Arity, [{file, File}, {line, Line}]}|Tl]) ->
-    Formated = #{module => erlang:atom_to_binary(Mod, utf8),
-                 function => erlang:atom_to_binary(Func, utf8),
-                 arity => format_arity(Arity, []),
-                 file => erlang:list_to_binary(File),
-                 line => Line},
-    [Formated|format_stacktrace(Tl)];
+format_stacktrace([{Mod, Func, Arity, TraceOpts}|Tl]) ->
+    File = case proplists:get_value(file, TraceOpts) of
+        undefined -> null;
+        F -> list_to_binary(F)
+    end,
+    Line = case proplists:get_value(line, TraceOpts) of
+        undefined -> null;
+        L -> L
+    end,
+    Formatted = #{
+        module => erlang:atom_to_binary(Mod, utf8),
+        function => erlang:atom_to_binary(Func, utf8),
+        arity => format_arity(Arity, []),
+        file => File,
+        line => Line
+    },
+    [Formatted|format_stacktrace(Tl)];
 format_stacktrace([Hd|Tl]) ->
     logger:warning("Could not format stacktrace line: ~p", [Hd]),
     format_stacktrace(Tl).


### PR DESCRIPTION
errors reported by erts internals do not have a file or line number. so implementing fallback to null