### PR TITLE
Better documentation

### DIFF
--- a/guides/handlers.md
+++ b/guides/handlers.md
@@ -1,8 +1,89 @@
 # Handlers
 
-## Handlers
+Handlers in Nova are functions that process and transform the output returned by controllers before sending a response to the client. They are essential for formatting responses, setting headers, encoding data, and customizing how your application communicates with users or other systems.
 
-Handlers are a nifty thing that is called on when the controller returns. For example if the controller returns
-`{json, #{hello => world}}` we would like Nova to create a proper JSON response to the requester. That means setting correct
-headers, encode the payload and send it out. This is what _handlers_ are for. They are (often short) functions that transforms something like
-`{json, Payload}` to proper output.
+## What are Handlers?
+
+When a controller returns a result such as `{json, #{hello => world}}`, Nova uses handlers to convert that tuple into a properly formatted HTTP response. This includes setting the correct headers, encoding the payload (e.g., to JSON), and sending it out to the client.
+
+Handlers are typically short, focused modules that define how to process specific types of controller return values.
+
+## Creating Custom Handlers
+
+You can create your own handlers to support custom response types or behaviors. Handlers are registered with Nova and invoked when a controller returns a tuple that matches their type.
+
+**Example: Custom Console Handler**
+
+```erlang
+-module(my_console_handler).
+-export([handle_console/4]).
+
+handle_console({_Type, Format, Args}, _Callback, Req) ->
+    io:format(Format, Args),
+    {ok, Req}.
+```
+
+To use this handler, register it in your application's supervisor or initialization logic (See more in the 'Registering a handler'-section).
+
+## Handler Return Types
+
+A handler can return two different types:
+
+- `{ok, Req}` – To continue the request process
+- `{error, Reason}` – Triggers Nova to render a 500 error page to the user.
+
+Remember that Nova is built around *Cowboy* so if you need to send a response to the requester then use `cowboy_req:reply/2`. Read more about cowboy_req at [https://ninenines.eu/docs/en/cowboy/2.6/manual/cowboy_req](https://ninenines.eu/docs/en/cowboy/2.6/manual/cowboy_req/)
+
+## Built-in Handlers
+
+Nova provides several built-in handlers for common response types, such as:
+
+- **JSON Handler:** Automatically encodes maps or lists as JSON and sets the `content-type` header. Use like `{json, StatusCode, Headers, Map}`
+- **HTML Handler:** Renders HTML templates and sets the appropriate headers. Use like `{ok, VariablesMap, OptionsMap}`
+- **HTTP Status handler:** Returns a plain HTTP status without any content. Use like `{status, StatusCode}`
+
+There's a few more and the easiest way to read more about them check the [docs](https://hexdocs.pm/nova/nova_basic_handler.html)
+
+## Usage Example
+
+Suppose your controller returns `{json, #{message => "Hello world"}}`. Nova's JSON handler will:
+
+1. Encode the map to JSON.
+2. Set the `content-type` header to `application/json`.
+3. Return the HTTP response to the client.
+
+**Controller Example:**
+
+```erlang
+-module(hello_controller).
+-export([greet/1]).
+
+greet(_Req) ->
+    {json, #{message => "Hello world"}}.
+```
+
+## Registering a Handler
+
+Handlers are registered using Nova’s API:
+
+```erlang
+nova_handlers:register_handler(custom_handler, my_custom_handler).
+```
+
+Once registered, when a controller returns `{custom_handler, Payload}`, Nova will use the specified handler to process the response.
+
+## Advanced Usage
+
+- You can define handlers for custom types, enabling new response patterns.
+- Handlers can also perform post-processing, such as logging, analytics, or header manipulation.
+- You may unregister or override default handlers if needed.
+
+## Best Practices
+
+- Keep handler logic focused and single-purpose.
+- Use handlers to centralize output formatting and minimize duplication in controllers.
+- Test custom handlers to ensure they react correctly to all expected and unexpected controller outputs.
+
+---
+
+For more details on available handlers or to see example implementations, check out the Nova source code or extend the documentation with your own custom handler recipe!s

--- a/guides/views.md
+++ b/guides/views.md
@@ -1,5 +1,64 @@
 # Views
 
-The views in Nova are powered by [erlydtl](https://github.com/erlydtl/erlydtl). They use the Django template language and compile down to Erlang.
+Nova uses the [erlydtl](https://github.com/erlydtl/erlydtl) template engine to power its view layer. erlydtl is an Erlang implementation of the Django template language, which makes templates both expressive and familiar to developers with experience in Django or similar frameworks.
 
-Please read the [erlydtl wiki](https://github.com/erlydtl/erlydtl/wiki) for more information regarding the templates.
+## How Views Work in Nova
+
+Views are responsible for rendering the final output sent to the client, typically HTML, but you can also use them for other formats. Nova compiles your templates to efficient Erlang code at build time, ensuring fast rendering.
+
+### Creating a View
+
+To create a view, place your template files (with the `.dtl` extension) in your application's `src/views` directory. For example:
+
+```
+src/views/
+  └── user_profile.dtl
+```
+
+A sample template might look like this:
+
+```html+django
+<h1>Welcome, {{ name }}!</h1>
+<p>Email: {{ email }}</p>
+```
+
+### Rendering a View from a Controller
+
+In your controller, you can render a view using Nova’s built-in helpers:
+
+```erlang
+Vars = #{name => "Alice", email => "alice@example.com"},
+{ok, Vars, #{view => user_profile}}.
+```
+
+The example above will then render the *user_profile.dtl* template.
+
+### Passing Data to Templates
+
+You pass variables to the template as a map. All keys in the map become available in the template as variables.
+
+### Template Features
+
+erlydtl supports:
+
+- **Template inheritance** (`{% extends %}`)
+- **Includes** (`{% include %}`)
+- **Control structures** (`{% if %}`, `{% for %}`)
+- **Filters** (`{{ value|escape }}`)
+- **Custom tags and filters** (advanced usage)
+
+For details on syntax and features, see the [erlydtl wiki](https://github.com/erlydtl/erlydtl/wiki).
+
+### Error Handling
+
+If a template is missing or a rendering error occurs, Nova will log the error and, depending on configuration, may return a generic error page or propagate the details in development mode.
+
+### Best Practices
+
+- Organize templates in subfolders for maintainability.
+- Use template inheritance to avoid duplication.
+- Validate your data before passing it to the template.
+
+---
+
+For more about advanced template syntax, custom filters, and extending views, read the [erlydtl documentation](https://github.com/erlydtl/erlydtl/wiki).


### PR DESCRIPTION
This pull request updates the Nova documentation and improves HTTP method error handling in the router. The most significant changes are expanded guides for handlers and views, and enhanced response headers for 405 errors.

**Documentation improvements:**

* Expanded the `guides/handlers.md` guide to clearly explain what handlers are, how to create and register custom handlers, built-in handler types, handler return values, usage examples, and best practices. Includes code samples and links to further documentation.
* Rewrote the `guides/views.md` guide to provide a comprehensive overview of Nova's view layer, including template organization, rendering from controllers, passing data, template features, error handling, and best practices.

**Router error handling:**

* Modified the router in `src/nova_router.erl` to set the `allow` response header when a request fails due to an unsupported HTTP method, providing the client with a list of allowed methods for that route. The debug log now also includes allowed methods.