### PR TITLE
Ensure one leading slash in urls created from erlydtl with {% url ...} tag

### DIFF
--- a/src/nova_erlydtl_inventory.erl
+++ b/src/nova_erlydtl_inventory.erl
@@ -23,5 +23,10 @@ url([Url|Variables], _Options) ->
             <<"#">>;
         Prefix ->
             PrefixBin = list_to_binary(Prefix),
-            << PrefixBin/binary, Url/binary >>
+            maybe_remove_starting_slash(<< PrefixBin/binary, Url/binary >>)
     end.
+
+maybe_remove_starting_slash(<<"/", "/", Rest/binary>>) ->
+    <<"/", Rest/binary>>;
+maybe_remove_starting_slash(Url) ->
+    Url.


### PR DESCRIPTION
This pull request introduces a small but important update to the URL handling logic in `src/nova_erlydtl_inventory.erl`. The change ensures that URLs with double leading slashes are normalized to a single leading slash, improving consistency in URL formatting.

* Added the `maybe_remove_starting_slash/1` helper function to normalize URLs by converting double leading slashes to a single slash. Updated the `url/2` function to use this helper when constructing URLs.… in our erlydtl_tag "url"