### PR TITLE
Allow controller modules to define their own routes

### DIFF
--- a/src/nova_basic_handler.erl
+++ b/src/nova_basic_handler.erl
@@ -319,6 +319,7 @@ render_dtl(View, Variables, Options) ->
     end.
 
 
+get_view_name({Mod, _Opts}) -> get_view_name(Mod);
 get_view_name(Mod) when is_atom(Mod) ->
     StrName = get_view_name(erlang:atom_to_list(Mod)),
     erlang:list_to_atom(StrName);

--- a/src/nova_controller.erl
+++ b/src/nova_controller.erl
@@ -1,0 +1,31 @@
+%%% @doc
+%%% Nova Controller behaviour definition
+%%% @end
+
+-module(nova_controller).
+
+-export([routes/2]).
+
+-optional_callbacks([routes/2]).
+
+%% @doc Returns the routes defined in the module, if any
+-callback routes(Env :: atom(), Opts :: map()) -> Routes :: [map()].
+
+
+-spec routes(module() | {module(), map()}, Env :: atom()) -> Routes :: [map()].
+routes({Module, Opts}, Env) when is_map(Opts) ->
+    routes(Module, Env, Opts);
+routes(Module, Env) ->
+    routes(Module, Env, #{}).
+
+routes(Module, Env, Opts) ->
+    %% try to ensure callback module is loaded first
+    try Module:module_info(module)
+    catch _:_ -> ok
+    end,
+    case erlang:function_exported(Module, routes, 2) of
+        true ->
+            Module:routes(Env, Opts);
+        false ->
+            []
+    end.


### PR DESCRIPTION
Based on how cowboy_swagger works: Allow each controller module to list its own routes, instead of having them all in the main routing module.

Adds a new behaviour `nova_controller` with an optional callback `routes/2`. Routes from the controller modules will be combined with those (if any) in the main routing module; the `routes/1`callback in the router behaviour is made optional. The routing module can instead list the controller modules via a new optional callback `controllers/1`, and doesn't need to know any further details. 

The additional options parameter in the controller callback `routes/2` makes it possible to have multiple instances of the same controller module using different configurations.