### PR TITLE
Add optional callback `start_link/0` to `nova_session` behaviour

### DIFF
--- a/guides/sessions.md
+++ b/guides/sessions.md
@@ -56,14 +56,15 @@ This function is used to delete all values. It takes one argument: the request o
 nova_session:delete(Req).
 ```
 
-## Enabling Sessionss
+## Enabling Sessions
 
 Sessions are enabled by default in Nova, but if you need to disable them, you can do so by setting the `use_sessions` configuration option to `false`. This will disable sessions for the entire site.
 It's also possible to set the backend for the session data. By default, the session data is stored in an *ETS* table in the Erlang VM but it's quite easy to implement a custom backend.
 
 ## Backend
 
-You can implement your own backend by creating a module that implements the `nova_session` behaviour. This behaviour has four functions that need to be implemented: `get/2`, `set/3`, `delete/1` and `delete/2`.
+You can implement your own backend by creating a module that implements the `nova_session` behaviour. This behaviour has four functions that need to be implemented: `get_value/2`, `set_value/3`, `delete_value/1` and `delete_value/2`.  
+Optionally you can also implement `start_link/0`, which will start a process under nova's supervisor for handling infrastructure of your handler, if it is necessary. For example, in default `nova_session_ets` module it starts a `gen_server` for managing underlying *ETS* table. 
 
 ```erlang
 -module(my_session_backend).

--- a/src/nova_session.erl
+++ b/src/nova_session.erl
@@ -47,6 +47,15 @@
         when SessionId :: binary(),
              Key :: binary().
 
+%% Start a server process for session backend, if necessary
+-callback start_link() ->
+    {ok, Pid :: pid()} |
+    {error, Error :: {already_started, pid()}} |
+    {error, Error :: term()} |
+    ignore.
+
+-optional_callbacks([start_link/0]).
+
 %%%===================================================================
 %%% Public functions
 %%%===================================================================

--- a/src/nova_session_ets.erl
+++ b/src/nova_session_ets.erl
@@ -9,6 +9,7 @@
 -module(nova_session_ets).
 
 -behaviour(gen_server).
+-behaviour(nova_session).
 
 %% API
 -export([

--- a/src/nova_sup.erl
+++ b/src/nova_sup.erl
@@ -66,19 +66,17 @@ init([]) ->
 
     SessionManager = application:get_env(nova, session_manager, nova_session_ets),
 
-    Children = [
-                child(nova_handlers, nova_handlers),
-                child(SessionManager, SessionManager),
-                child(nova_watcher, nova_watcher)
-               ],
+    Children0 = [child(nova_handlers, nova_handlers), child(nova_watcher, nova_watcher)],
+    Children =
+        case erlang:function_exported(SessionManager, start_link, 0) of
+            true -> [child(SessionManager, SessionManager) | Children0];
+            false -> Children0
+        end,
 
     setup_cowboy(Configuration),
 
 
     {ok, {SupFlags, Children}}.
-
-
-
 
 %%%===================================================================
 %%% Internal functions


### PR DESCRIPTION
\+ handle case when it is not exported.  

Fixes https://github.com/novaframework/nova/issues/336