### PR TITLE
chore: migrate CI to erlang-ci reusable workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,33 @@
+name: Dependency Audit
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  audit:
+    name: Audit dependencies
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "28.0"
+          rebar3-version: "3.25.0"
+          version-type: strict
+
+      - name: Inject rebar3_audit plugin
+        run: |
+          echo '{project_plugins, [{rebar3_audit, {git, "https://github.com/Taure/rebar3_audit.git", {tag, "v0.1.0"}}}]}.' >> rebar.config
+
+      - name: Audit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: rebar3 audit --token "${GITHUB_TOKEN}"
+
+      - name: Clean up
+        if: always()
+        run: git checkout rebar.config

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -6,114 +6,17 @@ on:
   pull_request:
 
 jobs:
-  build:
-    runs-on: ubuntu-24.04
-    name: Erlang/OTP ${{matrix.otp}} / rebar3 ${{matrix.rebar3}}
-    strategy:
-      fail-fast: false
-      matrix:
-        otp: ['26.1', '27.1', '28.0']
-        rebar3: ['3.25.0']
-    steps:
-    - uses: actions/checkout@v6
-    - uses: erlef/setup-beam@v1
-      with:
-        otp-version: ${{matrix.otp}}
-        rebar3-version: ${{matrix.rebar3}}
-        version-type: strict
-    - name: Cache rebar3 deps and build
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cache/rebar3
-          _build
-        key: ${{runner.os}}-rebar3-${{matrix.otp}}-${{matrix.rebar3}}-${{hashFiles('rebar.lock')}}
-        restore-keys: |
-          ${{runner.os}}-rebar3-${{matrix.otp}}-${{matrix.rebar3}}-
-    - name: Compile
-      run: rebar3 compile
-  eunit:
-    needs: [build]
-    runs-on: ubuntu-24.04
-    name: EUnit Erlang/OTP ${{matrix.otp}} / rebar3 ${{matrix.rebar3}}
-    strategy:
-      fail-fast: false
-      matrix:
-        otp: ['26.1', '27.1', '28.0']
-        rebar3: ['3.25.0']
-    steps:
-    - uses: actions/checkout@v6
-    - uses: erlef/setup-beam@v1
-      with:
-        otp-version: ${{matrix.otp}}
-        rebar3-version: ${{matrix.rebar3}}
-        version-type: strict
-    - name: Cache rebar3 deps and build
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cache/rebar3
-          _build
-        key: ${{runner.os}}-rebar3-${{matrix.otp}}-${{matrix.rebar3}}-${{hashFiles('rebar.lock')}}
-        restore-keys: |
-          ${{runner.os}}-rebar3-${{matrix.otp}}-${{matrix.rebar3}}-
-    - name: Run eunit
-      run: rebar3 eunit
-  dialyzer:
-    runs-on: ubuntu-24.04
-    name: Dialyzer Erlang/OTP ${{matrix.otp}} / rebar3 ${{matrix.rebar3}}
-    strategy:
-      fail-fast: false
-      matrix:
-        otp: ['26.1', '27.1', '28.0']
-        rebar3: ['3.25.0']
-    steps:
-    - uses: actions/checkout@v6
-    - uses: erlef/setup-beam@v1
-      with:
-        otp-version: ${{matrix.otp}}
-        rebar3-version: ${{matrix.rebar3}}
-        version-type: strict
-    - name: Cache rebar3 deps and build
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cache/rebar3
-          _build
-        key: ${{runner.os}}-rebar3-${{matrix.otp}}-${{matrix.rebar3}}-${{hashFiles('rebar.lock')}}
-        restore-keys: |
-          ${{runner.os}}-rebar3-${{matrix.otp}}-${{matrix.rebar3}}-
-    - name: Run dialyzer
-      run: rebar3 dialyzer
-  xref:
-    runs-on: ubuntu-24.04
-    name: Xref Erlang/OTP ${{matrix.otp}} / rebar3 ${{matrix.rebar3}}
-    strategy:
-      fail-fast: false
-      matrix:
-        otp: ['26.1', '27.1', '28.0']
-        rebar3: ['3.25.0']
-    steps:
-    - uses: actions/checkout@v6
-    - uses: erlef/setup-beam@v1
-      with:
-        otp-version: ${{matrix.otp}}
-        rebar3-version: ${{matrix.rebar3}}
-        version-type: strict
-    - name: Cache rebar3 deps and build
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cache/rebar3
-          _build
-        key: ${{runner.os}}-rebar3-${{matrix.otp}}-${{matrix.rebar3}}-${{hashFiles('rebar.lock')}}
-        restore-keys: |
-          ${{runner.os}}-rebar3-${{matrix.otp}}-${{matrix.rebar3}}-
-    - name: Run xref
-      run: rebar3 xref
+  ci:
+    uses: Taure/erlang-ci/.github/workflows/ci.yml@v1
+    with:
+      otp-version: '28.0'
+      rebar3-version: '3.25.0'
+      otp-matrix: '["26.1", "27.1", "28.0"]'
+      enable-fmt: true
+
   nova_request_app:
     if: github.ref != 'refs/heads/master'
-    needs: [build]
+    needs: [ci]
     uses: ./.github/workflows/run_nra.yml
     with:
       branch: ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
## Summary
- Replaces 122 lines of duplicated workflow YAML with `Taure/erlang-ci` reusable workflow
- Runs compile, fmt, xref, dialyzer, eunit with OTP matrix (26.1, 27.1, 28.0)
- Keeps nova_request_app integration test job

## Test plan
- [ ] Verify all CI jobs pass (compile, fmt, xref, dialyzer, eunit x3)
- [ ] Verify nova_request_app job still triggers on PRs

Uses https://github.com/Taure/erlang-ci