### PR TITLE
refactor: use binary format strings in logger calls

### DIFF
--- a/include/nova.hrl
+++ b/include/nova.hrl
@@ -1,5 +1,3 @@
--define(LOG_DEPRECATED(SinceVersion, Msg), logger:warning("Deprecation warning. Since version: ~s, Message: ~s~nRead more"
-                                                          " about deprecations on https://github.com/novaframework/nova/blob/master/guides/deprecations.md", [SinceVersion, Msg])).
+-define(LOG_DEPRECATED(SinceVersion, Msg), logger:warning(<<"Deprecation warning. Since version: ~s, Message: ~s~nRead more about deprecations on https://github.com/novaframework/nova/blob/master/guides/deprecations.md">>, [SinceVersion, Msg])).
 
--define(LOG_DEPRECATED(SinceVersion, Msg, File), logger:warning("Deprecation warning. Since version: ~s, Message: ~s~nRead more about "
-                                                                "deprecations on https://github.com/novaframework/nova/blob/master/guides/deprecations.md\nFound in file: ~s", [SinceVersion, Msg, File])).
+-define(LOG_DEPRECATED(SinceVersion, Msg, File), logger:warning(<<"Deprecation warning. Since version: ~s, Message: ~s~nRead more about deprecations on https://github.com/novaframework/nova/blob/master/guides/deprecations.md\nFound in file: ~s">>, [SinceVersion, Msg, File])).

--- a/src/controllers/nova_error_controller.erl
+++ b/src/controllers/nova_error_controller.erl
@@ -87,7 +87,7 @@ server_error(#{crash_info := #{class := Class, reason := Reason}} = Req) ->
 
 
 format_stacktrace(not_enabled) ->
-    logger:warning("Stacktrace disabled. If you want to enable stacktraces call nova:stracktrace(true) or update your sys.config - Read more in the docs"),
+    logger:warning(<<"Stacktrace disabled. If you want to enable stacktraces call nova:stracktrace(true) or update your sys.config - Read more in the docs">>),
     [];
 format_stacktrace([]) -> [];
 format_stacktrace([{Mod, Func, Arity, TraceOpts}|Tl]) ->
@@ -103,7 +103,7 @@ format_stacktrace([{Mod, Func, Arity, TraceOpts}|Tl]) ->
                  line => Line},
     [Formated|format_stacktrace(Tl)];
 format_stacktrace([Hd|Tl]) ->
-    logger:warning("Could not format stacktrace line: ~p", [Hd]),
+    logger:warning(<<"Could not format stacktrace line: ~p">>, [Hd]),
     format_stacktrace(Tl).
 
 
@@ -113,7 +113,7 @@ format_arity(Arity) when is_function(Arity) -> <<"fun">>;
 format_arity(Arity) -> Arity.
 
 format_arity([], Acc) ->
-    logger:warning("Acc: ~p~n", [Acc]),
+    logger:warning(<<"Acc: ~p~n">>, [Acc]),
     Acc;
 format_arity([Head, Tail], Acc) ->
     Formated = format_arity(Head),

--- a/src/controllers/nova_error_controller.erl
+++ b/src/controllers/nova_error_controller.erl
@@ -113,7 +113,6 @@ format_arity(Arity) when is_function(Arity) -> <<"fun">>;
 format_arity(Arity) -> Arity.
 
 format_arity([], Acc) ->
-    logger:warning(<<"Acc: ~p~n">>, [Acc]),
     Acc;
 format_arity([Head, Tail], Acc) ->
     Formated = format_arity(Head),

--- a/src/nova_plugin_manager.erl
+++ b/src/nova_plugin_manager.erl
@@ -87,7 +87,7 @@ add_plugin(Callback) when is_function(Callback) ->
 add_plugin(Module, Name, Version) ->
     case ets:lookup(?TABLE, Module) of
         [#plugin{}] ->
-            ?LOG_DEBUG("Plugin ~p already initialized.", [Module]),
+            ?LOG_DEBUG(<<"Plugin ~p already initialized.">>, [Module]),
             ok;
         [] ->
             gen_server:cast(?SERVER, {add_plugin, Module, Name, Version})
@@ -107,7 +107,7 @@ get_state(Module) when is_atom(Module) ->
         [#plugin{state = State}] ->
             {ok, State};
         _ ->
-            ?LOG_DEBUG("Plugin ~p not found. get_state/1 failed.", [Module]),
+            ?LOG_DEBUG(<<"Plugin ~p not found. get_state/1 failed.">>, [Module]),
             {error, not_found}
     end;
 get_state(Callback) when is_function(Callback) ->
@@ -131,7 +131,7 @@ set_state(Module, NewState) when is_atom(Module) ->
         [#plugin{} = P] ->
             gen_server:call(?SERVER, {set_state, Module, P, NewState});
         _ ->
-            ?LOG_DEBUG("Plugin ~p not found. set_state/2 failed.", [Module]),
+            ?LOG_DEBUG(<<"Plugin ~p not found. set_state/2 failed.">>, [Module]),
             {error, not_found}
     end;
 set_state(Callback, NewState) when is_function(Callback) ->
@@ -177,7 +177,7 @@ init([]) ->
           {stop, Reason :: term(), Reply :: term(), NewState :: term()} |
           {stop, Reason :: term(), NewState :: term()}.
 handle_call({set_state, Module, P, NewState}, _From, State) ->
-    ?LOG_DEBUG("Set state for plugin ~p; NewState: ~p", [Module, NewState]),
+    ?LOG_DEBUG(<<"Set state for plugin ~p; NewState: ~p">>, [Module, NewState]),
     ets:insert(?TABLE, P#plugin{state = NewState}),
     {reply, ok, State};
 handle_call(_Request, _From, State) ->
@@ -199,10 +199,10 @@ handle_cast({add_plugin, Module, Name, Version}, State) ->
     PluginState =
         case erlang:function_exported(Module, init, 0) of
             true ->
-                ?LOG_INFO("Initializing plugin ~p", [Module]),
+                ?LOG_INFO(<<"Initializing plugin ~p">>, [Module]),
                 Module:init();
             _ ->
-                ?LOG_DEBUG("Plugin ~p has no init/0 function. Defaulting to empty map #{}", [Module]),
+                ?LOG_DEBUG(<<"Plugin ~p has no init/0 function. Defaulting to empty map #{}">>, [Module]),
                 #{}
         end,
     ets:insert(?TABLE, #plugin{module = Module, name = Name, version = Version, state = PluginState}),

--- a/src/nova_router.erl
+++ b/src/nova_router.erl
@@ -76,10 +76,10 @@ execute(Req = #{host := Host, path := Path, method := Method}, Env) ->
     Dispatch = StorageBackend:get(nova_dispatch),
     case routing_tree:lookup(Host, Path, Method, Dispatch) of
         {error, not_found} ->
-            logger:debug("Path ~p not found for ~p in ~p", [Path, Method, Host]),
+            logger:debug(<<"Path ~p not found for ~p in ~p">>, [Path, Method, Host]),
             render_status_page('_', 404, #{error => "Not found in path"}, Req, Env);
         {error, comparator_not_found, AllowedMethods} ->
-            logger:debug("Method not allowed: ~p for ~p. Allowed methods: ~p", [Method, Path, AllowedMethods]),
+            logger:debug(<<"Method not allowed: ~p for ~p. Allowed methods: ~p">>, [Method, Path, AllowedMethods]),
             %% Join the elements in AllowedMethods with a colon
             AllowHeader = iolist_to_binary(string:join([binary_to_list(M) || M <- AllowedMethods], ", ")),
             %% Set the 'allow'-header
@@ -253,8 +253,7 @@ compile_paths([RouteInfo|Tl], Dispatch, Options) ->
             false ->
                 false;
             {SMod, SFun} ->
-                ?LOG_DEPRECATED("v0.9.24", "The {Mod,Fun} format have been deprecated for "
-                                "the 'secure'-section of a route table. Use the new format for routes.", RouterFile),
+                ?LOG_DEPRECATED(<<"v0.9.24">>, <<"The {Mod,Fun} format have been deprecated for the 'secure'-section of a route table. Use the new format for routes.">>, RouterFile),
                 fun SMod:SFun/1;
             SCallback ->
                 SCallback


### PR DESCRIPTION
## Summary
- Replace list string `"..."` format strings with binary `<<"...">>` in all `logger` and `?LOG_*` macro calls
- Ensures log format strings are binaries instead of integer lists
- 4 files affected: `nova.hrl`, `nova_router.erl`, `nova_error_controller.erl`, `nova_plugin_manager.erl`

## Test plan
- [x] `rebar3 compile` passes
- [x] `rebar3 eunit` — all 347 tests pass