### PR TITLE
feat: support nested nova_apps

### DIFF
--- a/src/nova_sup.erl
+++ b/src/nova_sup.erl
@@ -150,7 +150,8 @@ start_cowboy(Configuration) ->
                 throw({error, no_nova_app_defined});
             App ->
                 ExtraApps = application:get_env(App, nova_apps, []),
-                nova_router:compile([nova|[App|ExtraApps]])
+                AllApps = resolve_nova_apps(ExtraApps, []),
+                nova_router:compile([nova|[App|AllApps]])
         end,
 
     CowboyOptions2 =
@@ -222,4 +223,22 @@ get_version(Application) ->
             erlang:list_to_binary(Version);
         false ->
             not_found
+    end.
+
+%% @doc Recursively resolve nested nova_apps.
+%% Each nova_app can declare its own nova_apps dependencies.
+%% Dependencies are resolved depth-first so child app routes
+%% are registered before the parent.
+-spec resolve_nova_apps([atom()], [atom()]) -> [atom()].
+resolve_nova_apps([], Acc) ->
+    lists:reverse(Acc);
+resolve_nova_apps([App | Rest], Acc) ->
+    case lists:member(App, Acc) of
+        true ->
+            %% Already resolved — skip to prevent cycles
+            resolve_nova_apps(Rest, Acc);
+        false ->
+            Nested = application:get_env(App, nova_apps, []),
+            Acc1 = resolve_nova_apps(Nested, [App | Acc]),
+            resolve_nova_apps(Rest, Acc1)
     end.

--- a/src/nova_sup.erl
+++ b/src/nova_sup.erl
@@ -150,8 +150,7 @@ start_cowboy(Configuration) ->
                 throw({error, no_nova_app_defined});
             App ->
                 ExtraApps = application:get_env(App, nova_apps, []),
-                AllApps = resolve_nova_apps(ExtraApps, []),
-                nova_router:compile([nova|[App|AllApps]])
+                nova_router:compile(resolve_nova_apps([nova, App | ExtraApps], []))
         end,
 
     CowboyOptions2 =


### PR DESCRIPTION
## Summary

Nova apps can now declare their own `nova_apps` dependencies. When compiling routes, Nova recursively resolves all nested nova_apps depth-first so child app routes are registered before the parent.

### Before

Users must manually list all transitive nova_apps:
```erlang
{my_app, [{nova_apps, [arizona_nova, shigoto_board]}]}
```

### After

Library apps declare their own dependencies:
```erlang
%% shigoto_board app env
{shigoto_board, [{nova_apps, [arizona_nova]}]}
```

Users only list what they need:
```erlang
{my_app, [{nova_apps, [shigoto_board]}]}
```

Nova resolves: `shigoto_board → arizona_nova` automatically.

### Implementation

- Added `resolve_nova_apps/2` to `nova_sup.erl`
- Recursive depth-first resolution
- Cycle detection (skips already-resolved apps)
- No changes to route compilation or existing behaviour

## Test plan

- [x] `rebar3 eunit` — 347 tests pass
- [x] `rebar3 xref` — clean
- [x] `rebar3 compile` — clean