### PR TITLE
feat(pubsub): allow binary channels, not just atoms

### DIFF
--- a/include/nova_pubsub.hrl
+++ b/include/nova_pubsub.hrl
@@ -1,5 +1,5 @@
 -record(nova_pubsub, {
-                      channel :: atom(),
+                      channel :: atom() | binary(),
                       sender :: pid(),
                       topic :: list() | binary(),
                       payload :: any()

--- a/src/nova_pubsub.erl
+++ b/src/nova_pubsub.erl
@@ -52,6 +52,13 @@
          get_local_members/1
         ]).
 
+-export_type([channel/0]).
+
+-type channel() :: atom() | binary().
+%% A pubsub channel. Backed by `pg', so any atom or binary works; binaries
+%% are useful for dynamic, per-entity channels (e.g. per-tenant) without
+%% growing the atom table.
+
 -define(SCOPE, nova_scope).
 
 -include("../include/nova_pubsub.hrl").
@@ -72,7 +79,7 @@ start() ->
 %% Joining a channel with the calling process. Always returns ok
 %% @end
 %%--------------------------------------------------------------------
--spec join(Channel :: atom()) -> ok.
+-spec join(Channel :: channel()) -> ok.
 join(Channel) ->
     join(Channel, self()).
 
@@ -82,7 +89,7 @@ join(Channel) ->
 %% calling process were not part of the channel.
 %% @end
 %%--------------------------------------------------------------------
--spec leave(Channel :: atom()) -> ok | not_joined.
+-spec leave(Channel :: channel()) -> ok | not_joined.
 leave(Channel) ->
     leave(Channel, self()).
 
@@ -92,7 +99,7 @@ leave(Channel) ->
 %% Same as join/1 but with a specified process.
 %% @end
 %%--------------------------------------------------------------------
--spec join(Channel :: atom(), Pid :: pid()) -> ok.
+-spec join(Channel :: channel(), Pid :: pid()) -> ok.
 join(Channel, Pid) when is_pid(Pid) ->
     pg:join(?SCOPE, Channel, Pid).
 
@@ -101,7 +108,7 @@ join(Channel, Pid) when is_pid(Pid) ->
 %% Same as leave/1 but with a specified process.
 %% @end
 %%--------------------------------------------------------------------
--spec leave(Channel :: atom(), Pid :: pid()) -> ok | not_joined.
+-spec leave(Channel :: channel(), Pid :: pid()) -> ok | not_joined.
 leave(Channel, Pid) ->
     pg:leave(?SCOPE, Channel, Pid).
 
@@ -111,7 +118,7 @@ leave(Channel, Pid) ->
 %% to differentiate messages within the same channel.
 %% @end
 %%--------------------------------------------------------------------
--spec broadcast(Channel :: atom(), Topic :: list() | binary(), Message :: any()) -> ok.
+-spec broadcast(Channel :: channel(), Topic :: list() | binary(), Message :: any()) -> ok.
 broadcast(Channel, Topic, Message) ->
     Members = get_members(Channel),
     Envelope = create_envelope(Channel, self(), Topic, Message),
@@ -125,7 +132,7 @@ broadcast(Channel, Topic, Message) ->
 %% node.
 %% @end
 %%--------------------------------------------------------------------
--spec local_broadcast(Channel :: atom(), Topic :: list() | binary(), Message :: any()) -> ok.
+-spec local_broadcast(Channel :: channel(), Topic :: list() | binary(), Message :: any()) -> ok.
 local_broadcast(Channel, Topic, Message) ->
     Members = get_local_members(Channel),
     Envelope = create_envelope(Channel, self(), Topic, Message),
@@ -138,7 +145,7 @@ local_broadcast(Channel, Topic, Message) ->
 %% Returns all members for a given channel
 %% @end
 %%--------------------------------------------------------------------
--spec get_members(Channel :: atom()) -> [pid()].
+-spec get_members(Channel :: channel()) -> [pid()].
 get_members(Channel) ->
     pg:get_members(?SCOPE, Channel).
 
@@ -148,7 +155,7 @@ get_members(Channel) ->
 %% same node.
 %% @end
 %%--------------------------------------------------------------------
--spec get_local_members(Channel :: atom()) -> [pid()].
+-spec get_local_members(Channel :: channel()) -> [pid()].
 get_local_members(Channel) ->
     pg:get_local_members(?SCOPE, Channel).
 

--- a/test/nova_pubsub_tests.erl
+++ b/test/nova_pubsub_tests.erl
@@ -23,6 +23,7 @@ nova_pubsub_test_() ->
       fun empty_channel_returns_empty/0,
       fun multiple_processes_same_channel/0,
       fun envelope_structure/0,
+      fun binary_channel_join_and_broadcast/0,
       fun start_returns_ok/0
      ]}.
 
@@ -109,6 +110,15 @@ envelope_structure() ->
     ?assertEqual("test_topic", Msg#nova_pubsub.topic),
     ?assertEqual(#{data => 42}, Msg#nova_pubsub.payload),
     nova_pubsub:leave(Channel).
+
+binary_channel_join_and_broadcast() ->
+    Channel = <<"tenant:", (integer_to_binary(erlang:unique_integer([positive])))/binary>>,
+    ?assertEqual(ok, nova_pubsub:join(Channel)),
+    ?assert(lists:member(self(), nova_pubsub:get_members(Channel))),
+    ?assertEqual(ok, nova_pubsub:broadcast(Channel, <<"t">>, payload)),
+    ?assertMatch(#nova_pubsub{channel = Channel, payload = payload}, recv()),
+    ?assertEqual(ok, nova_pubsub:leave(Channel)),
+    ?assertNot(lists:member(self(), nova_pubsub:get_members(Channel))).
 
 start_returns_ok() ->
     ?assertEqual(ok, nova_pubsub:start()).


### PR DESCRIPTION
## What

Widen the `nova_pubsub` channel type from `atom()` to a new exported `channel()` type (`atom() | binary()`), and update the `#nova_pubsub.channel` record field accordingly.

## Why

`nova_pubsub` is backed by `pg`, which already accepts any term as a group key - so this is a pure type/spec change with no runtime behaviour change. Atom-only channels force dynamic, per-entity pub/sub (e.g. one channel per tenant) to either mint atoms at runtime (atom table never shrinks) or share a global channel (cross-entity message leakage). Allowing binary channels lets callers use `<<"tenant:", Id/binary>>`-style channels safely.

## Changes

- `nova_pubsub`: new `-type channel() :: atom() | binary().` (exported + documented), all specs updated.
- `nova_pubsub.hrl`: `channel` field widened to `atom() | binary()`.
- Test: added a binary-channel join/broadcast/leave case (11 tests pass).

Backwards compatible - existing atom channels are unaffected.