### PR TITLE
fix: use SPDX 'Apache-2.0' license identifier for Hex

### DIFF
--- a/src/nova.app.src
+++ b/src/nova.app.src
@@ -19,5 +19,5 @@
   {env,[]},
   {modules,[nova]},
   {doc, "doc"},
-  {licenses,["Apache 2.0"]},
+  {licenses,["Apache-2.0"]},
   {links,[{"GitHub","https://github.com/novaframework/nova"}]}]}.


### PR DESCRIPTION
`src/nova.app.src` declared `{licenses, ["Apache 2.0"]}`. Hex expects an SPDX license identifier; `Apache 2.0` is not valid SPDX and gets flagged on publish. Corrected to the canonical `Apache-2.0`.

The bundled `LICENSE` is already the Apache License 2.0 text, so this is a metadata-naming fix only. No `vsn` or other fields touched.