### PR TITLE
ci: skip release on docs-only changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,11 @@ on:
   push:
     branches: [master]
     paths-ignore:
-      - '**/*.md'
+      - '**/*.md'       # README, AGENTS.md, CLAUDE.md, docs
       - 'docs/**'
+      - '.claude/**'    # repo-level agent config (Claude Code agents/commands/hooks)
+      - AGENTS.md
+      - CLAUDE.md
       - LICENSE
       - .gitignore
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: Release
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - LICENSE
+      - .gitignore
 
 permissions:
   contents: write


### PR DESCRIPTION
The custom `release.yml` triggers on every push to `master` and, because a `docs:` commit doesn't match feat/fix/breaking, falls through to the "default to patch if any commits exist" fallback - so a docs-only merge still cuts a patch release.

This adds `paths-ignore` to the release trigger so a merge touching **only** `**/*.md`, `docs/**`, `LICENSE`, or `.gitignore` does not run the release job and therefore does not bump the version. Any merge that also touches code still tags as before.

Matches the docs-skip convention already used elsewhere in the fleet.