### PR TITLE
deps: bump cowboy 2.15.0 -> 2.18.0 (CVE-2026-43966)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,7 @@
                ]}.
 
 {deps, [
-        {cowboy, "2.15.0"},
+        {cowboy, "2.18.0"},
         {erlydtl, "0.14.0"},
         {jhn_stdlib, "5.11.2"},
         {routing_tree, "1.0.11"},
@@ -88,4 +88,4 @@
 ]}.
 
 %% cowboy hex package declares deps with "and" syntax that rebar3 cannot parse.
-{overrides, [{override, cowboy, [{deps, [{cowlib, "2.16.1"}, {ranch, "2.2.0"}]}]}]}.
+{overrides, [{override, cowboy, [{deps, [{cowlib, "2.19.0"}, {ranch, "2.2.0"}]}]}]}.


### PR DESCRIPTION
cowboy `< 2.16.0` has an HTTP request/response splitting vulnerability (GHSA-w4f7-4cxr-rv3c / CVE-2026-43966, published 2026-07-29). Nova pins `{cowboy, "2.15.0"}`, so every Nova app inherits the vulnerable version and fails `rebar3 audit`.

- Bumps `cowboy` 2.15.0 -> 2.18.0.
- Updates the manual cowboy dep override (Nova hand-specifies cowboy's deps because rebar3 can't parse cowboy's "and" syntax): `cowlib` 2.16.1 -> 2.19.0, `ranch` unchanged at 2.2.0 — the versions cowboy 2.18.0 resolves against.

Nova compiles clean against 2.18.0 (only the pre-existing `catch` deprecation warnings). Downstream apps can drop any local cowboy override once this releases.