### PR TITLE
fix: splice a list-valued websocket reply into the command list

### DIFF
--- a/src/nova_basic_handler.erl
+++ b/src/nova_basic_handler.erl
@@ -268,14 +268,17 @@ handle_websocket({websocket, ControllerData}, Callback, Req) ->
 %% returned and the state. And the handler should return what cowboy expects.
 %%
 %% Example of a valid return value is {reply, Frame, State}
+%%
+%% The reply payload may be a single frame or a list of them, per
+%% nova_websocket:call_result/0.
 %% @end
 %%-----------------------------------------------------------------
-handle_ws({reply, Frame, NewControllerData}, State = #{commands := Commands}) ->
+handle_ws({reply, Frames, NewControllerData}, State = #{commands := Commands}) ->
     State#{controller_data => NewControllerData,
-           commands => [Frame|Commands]};
-handle_ws({reply, Frame, NewControllerData, hibernate}, State = #{commands := Commands}) ->
+           commands => prepend_frames(Frames, Commands)};
+handle_ws({reply, Frames, NewControllerData, hibernate}, State = #{commands := Commands}) ->
     State#{controller_data => NewControllerData,
-           commands => [Frame|Commands],
+           commands => prepend_frames(Frames, Commands),
            hibernate => true};
 handle_ws({ok, NewControllerData}, State) ->
     State#{controller_data => NewControllerData};
@@ -291,6 +294,19 @@ handle_ws(ok, State) ->
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
+
+%% nova_ws_handler passes `commands' to cowboy untouched, and cowboy treats
+%% every top-level element as one command - so a list-valued reply has to be
+%% spliced in, not consed as a single element. Consing it made the whole list
+%% arrive at cow_ws:frame/2 as if it were one frame, which is a function_clause
+%% that takes the connection process down with it.
+%%
+%% No cow_ws:frame() is itself a list (they are atoms and tuples), so is_list/1
+%% separates the two shapes unambiguously. An empty list contributes nothing.
+prepend_frames(Frames, Commands) when is_list(Frames) ->
+    Frames ++ Commands;
+prepend_frames(Frame, Commands) ->
+    [Frame|Commands].
 
 handle_view(View, Variables, Options, Req) ->
     Variables1 = maybe_inject_csrf_token(Variables, Req),

--- a/test/nova_basic_handler_tests.erl
+++ b/test/nova_basic_handler_tests.erl
@@ -136,6 +136,56 @@ handle_ws_reply_hibernate_test() ->
     ?assertEqual(true, maps:get(hibernate, Result)),
     ?assertEqual([{text, <<"b">>}, {text, <<"a">>}], maps:get(commands, Result)).
 
+%% nova_websocket:call_result/0 allows [cow_ws:frame()], and nova_ws_handler
+%% hands `commands' to cowboy untouched - cowboy reads that list left to right,
+%% one command per element. A list-valued reply must therefore be spliced in
+%% order. Consing it instead delivered the whole list to cow_ws:frame/2 as a
+%% single frame and killed the connection process with a function_clause.
+handle_ws_reply_frame_list_test() ->
+    State = #{controller_data => #{}, commands => []},
+    Result = nova_basic_handler:handle_ws(
+        {reply, [{text, <<"a">>}, {text, <<"b">>}], #{new => data}}, State),
+    ?assertEqual(#{new => data}, maps:get(controller_data, Result)),
+    ?assertEqual([{text, <<"a">>}, {text, <<"b">>}], maps:get(commands, Result)).
+
+%% Frame order is wire order, so the list may not be reversed on the way in.
+handle_ws_reply_frame_list_preserves_order_test() ->
+    Frames = [{text, <<"1">>}, {binary, <<"2">>}, {text, <<"3">>}],
+    State = #{controller_data => #{}, commands => []},
+    Result = nova_basic_handler:handle_ws({reply, Frames, #{}}, State),
+    ?assertEqual(Frames, maps:get(commands, Result)).
+
+handle_ws_reply_frame_list_keeps_earlier_commands_last_test() ->
+    State = #{controller_data => #{}, commands => [{text, <<"earlier">>}]},
+    Result = nova_basic_handler:handle_ws(
+        {reply, [{text, <<"a">>}, {text, <<"b">>}], #{}}, State),
+    ?assertEqual(
+        [{text, <<"a">>}, {text, <<"b">>}, {text, <<"earlier">>}],
+        maps:get(commands, Result)).
+
+handle_ws_reply_empty_frame_list_test() ->
+    State = #{controller_data => #{}, commands => [{text, <<"earlier">>}]},
+    Result = nova_basic_handler:handle_ws({reply, [], #{}}, State),
+    ?assertEqual([{text, <<"earlier">>}], maps:get(commands, Result)).
+
+handle_ws_reply_frame_list_hibernate_test() ->
+    State = #{controller_data => #{}, commands => []},
+    Result = nova_basic_handler:handle_ws(
+        {reply, [{text, <<"a">>}, {text, <<"b">>}], #{}, hibernate}, State),
+    ?assertEqual(true, maps:get(hibernate, Result)),
+    ?assertEqual([{text, <<"a">>}, {text, <<"b">>}], maps:get(commands, Result)).
+
+%% close/ping/pong are bare atoms rather than tuples; they must still be treated
+%% as one frame and not mistaken for anything list-shaped.
+handle_ws_reply_atom_frame_test() ->
+    State = #{controller_data => #{}, commands => []},
+    [
+        ?assertEqual(
+            [F],
+            maps:get(commands, nova_basic_handler:handle_ws({reply, F, #{}}, State)))
+     || F <- [close, ping, pong]
+    ].
+
 handle_ws_ok_test() ->
     State = #{controller_data => old, commands => []},
     Result = nova_basic_handler:handle_ws({ok, new_data}, State),

--- a/test/nova_ws_handler_tests.erl
+++ b/test/nova_ws_handler_tests.erl
@@ -199,6 +199,43 @@ websocket_info_reply_test_() ->
         ?assertMatch({[{text, <<"pong">>}], _}, Result)
     end}.
 
+%% The commands list goes to cowboy untouched and it reads one command per
+%% element, so a controller replying with several frames must produce several
+%% elements. Previously the whole list became one element and reached
+%% cow_ws:frame/2 as a single frame, taking the connection process down.
+websocket_info_reply_frame_list_test_() ->
+    {setup, ?SETUP, ?CLEANUP, fun() ->
+        meck:expect(test_ws_mod, websocket_info, fun(_Msg, CD) ->
+            {reply, [{text, <<"a">>}, {text, <<"b">>}], CD}
+        end),
+        State = make_ws_state(),
+        Result = nova_ws_handler:websocket_info(ping, State),
+        ?assertMatch({[{text, <<"a">>}, {text, <<"b">>}], _}, Result)
+    end}.
+
+websocket_handle_reply_frame_list_test_() ->
+    {setup, ?SETUP, ?CLEANUP, fun() ->
+        meck:expect(test_ws_mod, websocket_handle, fun(_Frame, CD) ->
+            {reply, [{text, <<"a">>}, {binary, <<"b">>}], CD}
+        end),
+        State = make_ws_state(),
+        Result = nova_ws_handler:websocket_handle({text, <<"hi">>}, State),
+        ?assertMatch({[{text, <<"a">>}, {binary, <<"b">>}], _}, Result)
+    end}.
+
+%% Every element cowboy receives has to be something cow_ws:frame/2 accepts.
+%% Asserting that directly is what would have caught the original defect: the
+%% shape looked right in the handler's return value and only failed inside
+%% cowboy.
+websocket_info_reply_frame_list_is_encodable_test_() ->
+    {setup, ?SETUP, ?CLEANUP, fun() ->
+        meck:expect(test_ws_mod, websocket_info, fun(_Msg, CD) ->
+            {reply, [{text, <<"a">>}, {text, <<"b">>}], CD}
+        end),
+        {Commands, _State} = nova_ws_handler:websocket_info(ping, make_ws_state()),
+        [?assertMatch(<<_/binary>>, iolist_to_binary(cow_ws:frame(F, #{}))) || F <- Commands]
+    end}.
+
 %%====================================================================
 %% terminate/3
 %%====================================================================


### PR DESCRIPTION
Closes #399.

`nova_websocket:call_result/0` documents

```erlang
{reply, OutFrame :: cow_ws:frame() | [OutFrame :: cow_ws:frame()], State :: map()}
```

but the list form killed the connection process.

`nova_basic_handler:handle_ws/2` consed the payload onto `commands` as a single element. `nova_ws_handler:handle_ws/4` hands that list to cowboy untouched, and cowboy treats every top-level element as one command — so a list-valued reply reached `cow_ws:frame/2` whole:

```
{function_clause,[{cow_ws,frame,[[{text,<<...>>},{text,<<...>>}],#{}],
   [{file,"cow_ws.erl"},{line,875}]},
 {cowboy_websocket,commands,3,...},
 {cowboy_websocket,handler_call_result,5,...}]}
```

Ranch logs the connection process exiting and the client's socket drops.

### The fix

```erlang
prepend_frames(Frames, Commands) when is_list(Frames) -> Frames ++ Commands;
prepend_frames(Frame, Commands) -> [Frame|Commands].
```

Order matters and is **not** reversed: `handle_ws/4` returns the accumulator to cowboy as-is, so its order is the order frames reach the wire. Splicing in place is therefore correct and `lists:reverse/1` would be wrong.

No `cow_ws:frame()` is itself a list — they are atoms (`close`, `ping`, `pong`) and tuples — so `is_list/1` separates the two shapes unambiguously. An empty list contributes nothing.

### Tests

Both levels, because the defect is only visible at the lower one:

- `nova_basic_handler_tests` — the command list built for a single frame, a list, an empty list, the hibernate variant, order preservation, earlier commands kept, and bare atom frames.
- `nova_ws_handler_tests` — what cowboy actually receives from `websocket_info/2` and `websocket_handle/2`, plus an assertion that **every element survives `cow_ws:frame/2`**. That last one is what would have caught the original bug: the controller's return value is correct in isolation, so a test one level up passes while the connection dies.

Reverting the source change fails 8 of them.

### Checks

`xref`, `dialyzer` (no warnings in the changed files), `eunit` 356/356, `ct`, `ex_doc`. `elp lint` reports one pre-existing L0002 on `nova_basic_handler.erl` that is also present on master (an ELP internal crash, not a code defect).

### How it was found

An application emitted two frames from one `websocket_info/2` clause. EUnit passed — the return value is right — and Common Test failed, because the defect only exists once Nova translates the return into cowboy commands.